### PR TITLE
feat(recipes): pubsub recipe zero-secret WI migration

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -134,10 +134,10 @@ Models three containerized services with Dapr sidecars, three Dapr components (s
 | Recipe | Azure Resource | Auth Model |
 |--------|---------------|------------|
 | `state-store.bicep` | Blob Storage (Standard_LRS) | RBAC (Storage Blob Data Contributor) |
-| `pubsub.bicep` | Service Bus Topics (Standard) | Connection string in recipe output; workload identity in deployment script |
+| `pubsub.bicep` | Service Bus Topics (Standard) | RBAC (Azure Service Bus Data Owner) — Entra metadata only, no connection string |
 | `secrets.bicep` | Key Vault (Standard, RBAC) | RBAC (Key Vault Secrets User) |
 
-All recipes enforce TLS 1.2, disable public blob access, and support optional RBAC role assignment. The pubsub recipe still outputs a connection string as a secret (transitional — the workload identity deployment script bypasses this).
+All recipes enforce TLS 1.2, disable public blob access, and support optional RBAC role assignment. All recipes output only Entra metadata — no connection strings or shared keys.
 
 #### Dapr Component Projection
 **Status:** ⚠️ Requires post-deploy backfill
@@ -424,8 +424,8 @@ The workflow routes expenses ≥ $100 to `ManualReviewRequested` but this is a t
 **[HIGH] Dapr Component CRD Auto-Projection**  
 Radius recipes provision Azure resources but do not create Kubernetes Dapr Component CRDs. The `deploy-dapr-components-workload-identity.sh` script fills this gap, but it means the deployment is not fully declarative through Radius alone. This is partly a Radius platform limitation, but RadiusClaim should track and adopt any upstream fix. In the meantime, the bootstrap script automates the backfill transparently.
 
-**[HIGH] Pubsub Recipe Workload Identity Migration**  
-The `pubsub.bicep` recipe still outputs a Service Bus connection string as a secret. While the deployment script bypasses this by configuring workload identity directly, the recipe itself should be updated to output only Entra metadata and RBAC assignments — matching the state-store recipe pattern. This closes the last gap in the zero-secret recipe layer.
+**[CLOSED] Pubsub Recipe Workload Identity Migration**  
+The `pubsub.bicep` recipe now outputs only Entra metadata (namespace endpoint, topic name) and assigns `Azure Service Bus Data Owner` RBAC — matching the zero-secret pattern established by `state-store.bicep`. No connection string is output. The zero-secret recipe layer is complete.
 
 **[HIGH] Automated Integration Tests**  
 No test suite exists beyond the CI smoke test (`validate-deployment.sh`). A proper test harness should cover: unit tests for approval logic, integration tests for Dapr workflow execution, and contract tests for inter-service communication. Phase 1 validation explicitly deferred this, but it's required for a complete reference app.

--- a/docs/end-to-end-setup-walkthrough.md
+++ b/docs/end-to-end-setup-walkthrough.md
@@ -892,7 +892,7 @@ The script:
 > # For managed identity: export AZURE_PRINCIPAL_ID=<managed-identity-object-id>
 > export AZURE_PRINCIPAL_ID="${AZURE_PRINCIPAL_ID:-$(az ad sp show --id "$AZURE_CLIENT_ID" --query id -o tsv)}"
 > ```
-> It then keeps the statestore on the supported Microsoft Entra/RBAC path and the pubsub component on **one** auth path only (`connectionString` for the current operator flow).
+> It then keeps both statestore and pubsub on the supported Microsoft Entra/RBAC path — no connection strings or shared keys required.
 
 **Dry run first** (generates YAML without applying):
 
@@ -1191,10 +1191,10 @@ kubectl get component statestore pubsub -n "$WORKLOAD_NAMESPACE" -o yaml
   ```
   Shared-key re-enable is not the tenant-safe fix anymore.
 
-- If the pubsub component contains both `namespaceName` and `connectionString`, remove one before restarting. For the current operator path, keep `connectionString` only:
+- If the pubsub component is in a mixed auth state (both `namespaceName` and `connectionString` present), patch it to the workload identity path:
   ```bash
   kubectl patch component pubsub -n "$WORKLOAD_NAMESPACE" --type merge \
-    -p '{"spec":{"metadata":[{"name":"connectionString","secretKeyRef":{"name":"pubsub-secrets","key":"connectionString"}},{"name":"disableEntityManagement","value":"true"}]}}'
+    -p '{"spec":{"metadata":[{"name":"namespaceName","value":"<namespace>.servicebus.windows.net"},{"name":"azureClientId","value":"'"$AZURE_CLIENT_ID"'"},{"name":"disableEntityManagement","value":"true"}]}}'
   kubectl rollout restart deployment/expense-api deployment/workflow-engine deployment/notification-svc -n "$WORKLOAD_NAMESPACE"
   ```
 

--- a/docs/radius-validation-checklist.md
+++ b/docs/radius-validation-checklist.md
@@ -709,20 +709,16 @@ kubectl get component statestore pubsub -n "$WORKLOAD_NAMESPACE" -o yaml
 
 **Interpretation:**
 - `KeyBasedAuthenticationNotPermitted` in `daprd` logs → `statestore` is using `accountKey`, but the backing storage account disallows shared-key auth.
-- `pubsub` metadata includes both `namespaceName` and `connectionString` → the pub/sub component is also invalid and will become the next blocker after statestore is repaired.
+- `pubsub` metadata includes `connectionString` instead of `namespaceName` + `azureClientId` → the pub/sub component is using the legacy connection string path. Re-run `deploy-dapr-components-workload-identity.sh` to patch it to workload identity.
 - Dapr annotations such as `dapr.io/enabled`, `dapr.io/app-id`, and `dapr.io/app-port` are **not** the problem when the sidecar dies during component initialization.
 
 **Fix path:**
 ```bash
 export AZURE_PRINCIPAL_ID="${AZURE_PRINCIPAL_ID:-$(az ad sp show --id "$AZURE_CLIENT_ID" --query id -o tsv)}"
 
-./scripts/deploy-dapr-components.sh \
+./scripts/deploy-dapr-components-workload-identity.sh \
   --resource-group <your-resource-group> \
   --namespace "$WORKLOAD_NAMESPACE"
-
-# Keep Service Bus on exactly one auth path: connectionString only for the current backfill flow
-kubectl patch component pubsub -n "$WORKLOAD_NAMESPACE" --type merge \
-  -p '{"spec":{"metadata":[{"name":"connectionString","secretKeyRef":{"name":"pubsub-secrets","key":"connectionString"}},{"name":"disableEntityManagement","value":"true"}]}}'
 
 kubectl rollout restart deployment/expense-api deployment/workflow-engine deployment/notification-svc \
   -n "$WORKLOAD_NAMESPACE"

--- a/infra/radius/recipes/azure/pubsub.bicep
+++ b/infra/radius/recipes/azure/pubsub.bicep
@@ -21,6 +21,20 @@ param subscriptionName string = 'notification-svc'
 ])
 param skuName string = 'Standard'
 
+@description('Microsoft Entra tenant ID used by the Dapr pubsub component.')
+param azureTenantId string = subscription().tenantId
+
+@description('Microsoft Entra client ID used by the Dapr pubsub component.')
+param azureClientId string = ''
+
+@description('Object ID of the Microsoft Entra principal that should receive Service Bus data-plane access.')
+param azurePrincipalId string = ''
+
+@description('Principal type for the Microsoft Entra identity used by the Dapr pubsub component.')
+param azurePrincipalType string = 'ServicePrincipal'
+
+var serviceBusDataOwnerRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419')
+
 resource namespace 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
   name: namespaceName
   location: location
@@ -44,7 +58,7 @@ resource topic 'Microsoft.ServiceBus/namespaces/topics@2024-01-01' = {
   }
 }
 
-resource subscription 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024-01-01' = {
+resource topicSubscription 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024-01-01' = {
   parent: topic
   name: subscriptionName
   properties: {
@@ -53,32 +67,39 @@ resource subscription 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024
   }
 }
 
-resource authRule 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2024-01-01' existing = {
-  parent: namespace
-  name: 'RootManageSharedAccessKey'
+resource serviceBusRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(azurePrincipalId)) {
+  name: guid(namespace.id, azurePrincipalId, 'servicebusDataOwner')
+  scope: namespace
+  properties: {
+    roleDefinitionId: serviceBusDataOwnerRoleDefinitionId
+    principalId: azurePrincipalId
+    principalType: azurePrincipalType
+  }
 }
 
-var authRuleKeys = authRule.listKeys()
+var pubsubMetadata = union({
+  namespaceName: {
+    value: '${namespace.name}.servicebus.windows.net'
+  }
+  disableEntityManagement: {
+    value: 'true'
+  }
+  azureTenantId: {
+    value: azureTenantId
+  }
+  azureEnvironment: {
+    value: 'AZUREPUBLICCLOUD'
+  }
+}, empty(azureClientId) ? {} : {
+  azureClientId: {
+    value: azureClientId
+  }
+})
 
-#disable-next-line outputs-should-not-contain-secrets
 output result object = {
   values: {
     type: 'pubsub.azure.servicebus.topics'
     version: 'v1'
-    metadata: {
-      namespaceName: {
-        value: '${namespace.name}.servicebus.windows.net'
-      }
-      disableEntityManagement: {
-        value: 'true'
-      }
-    }
-  }
-  secrets: {
-    metadata: {
-      connectionString: {
-        value: authRuleKeys.primaryConnectionString
-      }
-    }
+    metadata: pubsubMetadata
   }
 }

--- a/infra/radius/recipes/azure/pubsub.json
+++ b/infra/radius/recipes/azure/pubsub.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "12021420559950196974"
+      "templateHash": "9871730221095073567"
     }
   },
   "parameters": {
@@ -52,7 +52,39 @@
       "metadata": {
         "description": "Service Bus SKU used for the demo namespace."
       }
+    },
+    "azureTenantId": {
+      "type": "string",
+      "defaultValue": "[subscription().tenantId]",
+      "metadata": {
+        "description": "Microsoft Entra tenant ID used by the Dapr pubsub component."
+      }
+    },
+    "azureClientId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Microsoft Entra client ID used by the Dapr pubsub component."
+      }
+    },
+    "azurePrincipalId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Object ID of the Microsoft Entra principal that should receive Service Bus data-plane access."
+      }
+    },
+    "azurePrincipalType": {
+      "type": "string",
+      "defaultValue": "ServicePrincipal",
+      "metadata": {
+        "description": "Principal type for the Microsoft Entra identity used by the Dapr pubsub component."
+      }
     }
+  },
+  "variables": {
+    "serviceBusDataOwnerRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419')]",
+    "pubsubMetadata": "[union(createObject('namespaceName', createObject('value', format('{0}.servicebus.windows.net', parameters('namespaceName'))), 'disableEntityManagement', createObject('value', 'true'), 'azureTenantId', createObject('value', parameters('azureTenantId')), 'azureEnvironment', createObject('value', 'AZUREPUBLICCLOUD')), if(empty(parameters('azureClientId')), createObject(), createObject('azureClientId', createObject('value', parameters('azureClientId')))))]"
   },
   "resources": [
     {
@@ -93,6 +125,21 @@
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces/topics', parameters('namespaceName'), parameters('topicName'))]"
       ]
+    },
+    {
+      "condition": "[not(empty(parameters('azurePrincipalId')))]",
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[resourceId('Microsoft.ServiceBus/namespaces', parameters('namespaceName'))]",
+      "name": "[guid(resourceId('Microsoft.ServiceBus/namespaces', parameters('namespaceName')), parameters('azurePrincipalId'), 'servicebusDataOwner')]",
+      "properties": {
+        "roleDefinitionId": "[variables('serviceBusDataOwnerRoleDefinitionId')]",
+        "principalId": "[parameters('azurePrincipalId')]",
+        "principalType": "[parameters('azurePrincipalType')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('namespaceName'))]"
+      ]
     }
   ],
   "outputs": {
@@ -102,21 +149,7 @@
         "values": {
           "type": "pubsub.azure.servicebus.topics",
           "version": "v1",
-          "metadata": {
-            "namespaceName": {
-              "value": "[format('{0}.servicebus.windows.net', parameters('namespaceName'))]"
-            },
-            "disableEntityManagement": {
-              "value": "true"
-            }
-          }
-        },
-        "secrets": {
-          "metadata": {
-            "connectionString": {
-              "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/AuthorizationRules', parameters('namespaceName'), 'RootManageSharedAccessKey'), '2024-01-01').primaryConnectionString]"
-            }
-          }
+          "metadata": "[variables('pubsubMetadata')]"
         }
       }
     }


### PR DESCRIPTION
Closes #3

Removes Service Bus connection string output from `pubsub.bicep` and matches the zero-secret workload identity pattern established by `state-store.bicep`.

## Changes

### `infra/radius/recipes/azure/pubsub.bicep`
- Removed `authRule` resource reference and `listKeys()` call
- Removed `#disable-next-line outputs-should-not-contain-secrets` and secrets output block
- Added Entra parameters: `azureTenantId`, `azureClientId`, `azurePrincipalId`, `azurePrincipalType`
- Added `Azure Service Bus Data Owner` RBAC assignment (conditional on `azurePrincipalId`)
- Output now contains only Entra metadata: namespace FQDN, `disableEntityManagement`, tenant ID, environment, optional client ID

### Docs
- PRD: recipe auth table updated; pubsub WI gap marked CLOSED
- end-to-end-setup-walkthrough.md: connection string patch guidance replaced with WI path
- radius-validation-checklist.md: diagnostic and fix path updated to WI-only

## Acceptance Criteria
- [x] `pubsub.bicep` outputs no secrets — Entra/RBAC metadata only
- [x] Pattern matches `state-store.bicep`
- [x] Bicep compiles cleanly (`az bicep build` passes)
- [x] No `connectionString` in Dapr component output after deploy with this recipe