### PR TITLE
feat(workflow): add manual approval step for expenses >= $100

### DIFF
--- a/src/expense-api/Program.cs
+++ b/src/expense-api/Program.cs
@@ -155,6 +155,24 @@ expenses.MapGet("/{id}/workflow", async (
     return Results.Ok(workflowSnapshot);
 });
 
+// POST /expenses/{id}/approve — signals the paused workflow to approve the expense.
+expenses.MapPost("/{id}/approve", async (
+    string id,
+    ExpenseApprovalActionRequest? body,
+    DaprClient daprClient,
+    ILogger<Program> logger,
+    CancellationToken cancellationToken) =>
+    await HandleExpenseApprovalActionAsync(id, approved: true, body?.Reason, daprClient, logger, cancellationToken));
+
+// POST /expenses/{id}/reject — signals the paused workflow to reject the expense.
+expenses.MapPost("/{id}/reject", async (
+    string id,
+    ExpenseApprovalActionRequest? body,
+    DaprClient daprClient,
+    ILogger<Program> logger,
+    CancellationToken cancellationToken) =>
+    await HandleExpenseApprovalActionAsync(id, approved: false, body?.Reason, daprClient, logger, cancellationToken));
+
 expenses.MapGet("/{id}", async (string id, DaprClient daprClient, CancellationToken cancellationToken) =>
 {
     if (string.IsNullOrWhiteSpace(id))
@@ -427,6 +445,96 @@ static async Task TryStartExpenseWorkflowAsync(
     }
 }
 
+static async Task<IResult> HandleExpenseApprovalActionAsync(
+    string id,
+    bool approved,
+    string? reason,
+    DaprClient daprClient,
+    ILogger logger,
+    CancellationToken cancellationToken)
+{
+    if (string.IsNullOrWhiteSpace(id))
+    {
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["id"] = ["Expense id is required."]
+        });
+    }
+
+    var normalizedId = id.Trim();
+    var record = await daprClient.GetStateAsync<ExpenseRecord>(
+        RadiusClaimDapr.Components.StateStore,
+        RadiusClaimDapr.StateKeys.Expense(normalizedId),
+        consistencyMode: ConsistencyMode.Strong,
+        cancellationToken: cancellationToken);
+
+    if (record is null)
+    {
+        return Results.NotFound();
+    }
+
+    if (record.Status != ExpenseStatus.ManualReviewRequested)
+    {
+        return Results.Conflict(new
+        {
+            error = $"Expense '{normalizedId}' is not awaiting manual approval. Current status: {record.Status}.",
+            status = record.Status.ToString()
+        });
+    }
+
+    try
+    {
+        using var workflowClient = DaprClient.CreateInvokeHttpClient(RadiusClaimDapr.AppIds.WorkflowEngine);
+        var decisionBody = new { approved, reason };
+        using var response = await workflowClient.PostAsJsonAsync(
+            $"workflows/{Uri.EscapeDataString(record.CorrelationId)}/decide",
+            decisionBody,
+            cancellationToken);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return Results.Problem(
+                title: "Workflow instance not found.",
+                detail: $"No running workflow found for expense '{normalizedId}'.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+        {
+            return Results.Conflict(new
+            {
+                error = "The workflow is no longer waiting for a decision.",
+                expenseId = normalizedId
+            });
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        logger.LogInformation(
+            "Expense '{ExpenseId}' {Decision} signal sent to workflow '{InstanceId}'.",
+            normalizedId,
+            approved ? "approval" : "rejection",
+            record.CorrelationId);
+
+        return Results.Accepted(
+            $"/expenses/{normalizedId}/workflow",
+            new { expenseId = normalizedId, decision = approved ? "Approved" : "Rejected" });
+    }
+    catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+    {
+        logger.LogWarning(
+            ex,
+            "Could not send {Decision} signal to workflow for expense '{ExpenseId}'.",
+            approved ? "approval" : "rejection",
+            normalizedId);
+
+        return Results.Problem(
+            title: "Could not deliver decision to workflow.",
+            detail: "The approval/rejection signal could not be forwarded to the workflow engine.",
+            statusCode: StatusCodes.Status502BadGateway);
+    }
+}
+
 static async Task<ExpenseWorkflowSnapshot> GetExpenseWorkflowSnapshotAsync(
     ExpenseRecord record,
     ILogger logger,
@@ -602,5 +710,8 @@ internal sealed record ExpenseWorkflowSnapshot(
     DateTimeOffset? CreatedAtUtc,
     DateTimeOffset? LastUpdatedAtUtc,
     string? FailureDetails);
+
+/// <summary>Optional body for approve/reject endpoints. Both fields are optional.</summary>
+internal sealed record ExpenseApprovalActionRequest(string? Reason = null);
 
 public partial class Program;

--- a/src/shared/RadiusClaim.Contracts/ExpenseRecord.cs
+++ b/src/shared/RadiusClaim.Contracts/ExpenseRecord.cs
@@ -9,4 +9,5 @@ public sealed record ExpenseRecord(
     string Description,
     ExpenseStatus Status,
     DateTimeOffset SubmittedAtUtc,
-    DateTimeOffset LastUpdatedAtUtc);
+    DateTimeOffset LastUpdatedAtUtc,
+    string? RejectionReason = null);

--- a/src/shared/RadiusClaim.Contracts/RadiusClaimDapr.cs
+++ b/src/shared/RadiusClaim.Contracts/RadiusClaimDapr.cs
@@ -32,4 +32,10 @@ public static class RadiusClaimDapr
     {
         public const string ExpenseApproval = "ExpenseApprovalWorkflow";
     }
+
+    public static class WorkflowEvents
+    {
+        /// <summary>Event name raised by approve/reject API endpoints to resume a paused workflow.</summary>
+        public const string ExpenseDecision = "expense-decision";
+    }
 }

--- a/src/workflow-engine/Activities/ApproveExpenseActivity.cs
+++ b/src/workflow-engine/Activities/ApproveExpenseActivity.cs
@@ -1,15 +1,16 @@
 using RadiusClaim.Contracts;
 using Dapr.Client;
 using Dapr.Workflow;
+using Microsoft.Extensions.Options;
 using WorkflowEngine.Models;
 
 namespace WorkflowEngine.Activities;
 
 internal sealed class ApproveExpenseActivity(
     DaprClient daprClient,
+    IOptions<ApprovalOptions> approvalOptions,
     ILogger<ApproveExpenseActivity> logger) : WorkflowActivity<ExpenseSubmission, ApprovalDecision>
 {
-    private const decimal AutoApproveThreshold = 100.00m;
     private const string AutoApprovalDecisionSource = "AutoApprovedUnderThreshold";
     private const string ManualReviewDecisionSource = "ManualReviewThresholdReached";
 
@@ -33,7 +34,8 @@ internal sealed class ApproveExpenseActivity(
                 $"Expense '{input.ExpenseId}' correlation mismatch. Expected '{input.CorrelationId}', found '{record.CorrelationId}'.");
         }
 
-        var isAutoApproved = input.Amount < AutoApproveThreshold;
+        var threshold = approvalOptions.Value.ThresholdUsd;
+        var isAutoApproved = input.Amount < threshold;
         var nextStatus = isAutoApproved ? ExpenseStatus.Approved : ExpenseStatus.ManualReviewRequested;
         var decision = new ApprovalDecision(
             nextStatus,

--- a/src/workflow-engine/Activities/RecordApprovalActivity.cs
+++ b/src/workflow-engine/Activities/RecordApprovalActivity.cs
@@ -1,0 +1,71 @@
+using RadiusClaim.Contracts;
+using Dapr.Client;
+using Dapr.Workflow;
+
+namespace WorkflowEngine.Activities;
+
+/// <summary>
+/// Idempotent activity that transitions an expense from ManualReviewRequested → Approved
+/// in the state store. Called by the workflow after a human approver signals approval.
+/// </summary>
+internal sealed class RecordApprovalActivity(
+    DaprClient daprClient,
+    ILogger<RecordApprovalActivity> logger) : WorkflowActivity<string, bool>
+{
+    public override async Task<bool> RunAsync(WorkflowActivityContext context, string expenseId)
+    {
+        if (string.IsNullOrWhiteSpace(expenseId))
+        {
+            throw new ArgumentException("ExpenseId is required.", nameof(expenseId));
+        }
+
+        var normalizedId = expenseId.Trim();
+        var stateKey = RadiusClaimDapr.StateKeys.Expense(normalizedId);
+
+        var record = await daprClient.GetStateAsync<ExpenseRecord>(
+            RadiusClaimDapr.Components.StateStore,
+            stateKey);
+
+        if (record is null)
+        {
+            throw new InvalidOperationException(
+                $"Expense '{normalizedId}' was not found in state store before recording approval.");
+        }
+
+        // Idempotent: already approved or further along is fine.
+        if (record.Status is ExpenseStatus.Approved or ExpenseStatus.Reimbursed)
+        {
+            logger.LogInformation(
+                "Expense '{ExpenseId}' is already '{Status}' — skipping approval record (idempotent) for workflow '{InstanceId}'.",
+                normalizedId,
+                record.Status,
+                context.InstanceId);
+            return true;
+        }
+
+        if (record.Status != ExpenseStatus.ManualReviewRequested)
+        {
+            throw new InvalidOperationException(
+                $"Expense '{normalizedId}' cannot transition to Approved from status '{record.Status}'. " +
+                "Only ManualReviewRequested expenses can be manually approved.");
+        }
+
+        var updatedRecord = record with
+        {
+            Status = ExpenseStatus.Approved,
+            LastUpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        await daprClient.SaveStateAsync(
+            RadiusClaimDapr.Components.StateStore,
+            stateKey,
+            updatedRecord);
+
+        logger.LogInformation(
+            "Expense '{ExpenseId}' recorded as Approved (manual) for workflow '{InstanceId}'.",
+            normalizedId,
+            context.InstanceId);
+
+        return true;
+    }
+}

--- a/src/workflow-engine/Activities/RejectExpenseActivity.cs
+++ b/src/workflow-engine/Activities/RejectExpenseActivity.cs
@@ -1,0 +1,73 @@
+using RadiusClaim.Contracts;
+using Dapr.Client;
+using Dapr.Workflow;
+using WorkflowEngine.Models;
+
+namespace WorkflowEngine.Activities;
+
+/// <summary>
+/// Idempotent activity that transitions an expense from ManualReviewRequested → Rejected.
+/// Used for both human-initiated rejections and automatic timeout rejections.
+/// </summary>
+internal sealed class RejectExpenseActivity(
+    DaprClient daprClient,
+    ILogger<RejectExpenseActivity> logger) : WorkflowActivity<RejectionInput, bool>
+{
+    public override async Task<bool> RunAsync(WorkflowActivityContext context, RejectionInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (string.IsNullOrWhiteSpace(input.ExpenseId))
+        {
+            throw new ArgumentException("ExpenseId is required.", nameof(input));
+        }
+
+        var stateKey = RadiusClaimDapr.StateKeys.Expense(input.ExpenseId);
+        var record = await daprClient.GetStateAsync<ExpenseRecord>(
+            RadiusClaimDapr.Components.StateStore,
+            stateKey);
+
+        if (record is null)
+        {
+            throw new InvalidOperationException(
+                $"Expense '{input.ExpenseId}' was not found in state store before rejection.");
+        }
+
+        // Idempotent: already rejected is fine.
+        if (record.Status == ExpenseStatus.Rejected)
+        {
+            logger.LogInformation(
+                "Expense '{ExpenseId}' is already Rejected — skipping state update (idempotent) for workflow '{InstanceId}'.",
+                input.ExpenseId,
+                context.InstanceId);
+            return true;
+        }
+
+        if (record.Status != ExpenseStatus.ManualReviewRequested)
+        {
+            throw new InvalidOperationException(
+                $"Expense '{input.ExpenseId}' cannot be rejected from status '{record.Status}'. " +
+                "Only ManualReviewRequested expenses can be rejected.");
+        }
+
+        var updatedRecord = record with
+        {
+            Status = ExpenseStatus.Rejected,
+            RejectionReason = input.Reason,
+            LastUpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        await daprClient.SaveStateAsync(
+            RadiusClaimDapr.Components.StateStore,
+            stateKey,
+            updatedRecord);
+
+        logger.LogInformation(
+            "Expense '{ExpenseId}' rejected (reason: '{Reason}') for workflow '{InstanceId}'.",
+            input.ExpenseId,
+            input.Reason,
+            context.InstanceId);
+
+        return true;
+    }
+}

--- a/src/workflow-engine/ApprovalOptions.cs
+++ b/src/workflow-engine/ApprovalOptions.cs
@@ -1,0 +1,9 @@
+namespace WorkflowEngine;
+
+public sealed class ApprovalOptions
+{
+    public decimal ThresholdUsd { get; set; } = 100.0m;
+
+    /// <summary>Hours before an unresolved manual-approval auto-rejects. Default: 48.</summary>
+    public int ManualApprovalTimeoutHours { get; set; } = 48;
+}

--- a/src/workflow-engine/Models/ManualDecisionEvent.cs
+++ b/src/workflow-engine/Models/ManualDecisionEvent.cs
@@ -1,0 +1,6 @@
+namespace WorkflowEngine.Models;
+
+/// <summary>External event payload raised by the approve/reject API endpoints.</summary>
+internal sealed record ManualDecisionEvent(
+    bool Approved,
+    string? Reason = null);

--- a/src/workflow-engine/Models/RejectionInput.cs
+++ b/src/workflow-engine/Models/RejectionInput.cs
@@ -1,0 +1,6 @@
+namespace WorkflowEngine.Models;
+
+internal sealed record RejectionInput(
+    string ExpenseId,
+    string CorrelationId,
+    string Reason);

--- a/src/workflow-engine/Program.cs
+++ b/src/workflow-engine/Program.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using RadiusClaim.Contracts;
 using Dapr.Workflow;
+using WorkflowEngine;
 using WorkflowEngine.Activities;
 using WorkflowEngine.Models;
 using WorkflowEngine.Workflows;
@@ -18,6 +19,28 @@ builder.Services.AddDaprWorkflow(options =>
     options.RegisterActivity<ApproveExpenseActivity>();
     options.RegisterActivity<ProcessReimbursementActivity>();
     options.RegisterActivity<PublishNotificationActivity>();
+    options.RegisterActivity<RecordApprovalActivity>();
+    options.RegisterActivity<RejectExpenseActivity>();
+});
+
+// Bind from appsettings.json; override with APPROVAL_THRESHOLD_USD / APPROVAL_TIMEOUT_HOURS env vars if set.
+builder.Services.Configure<ApprovalOptions>(builder.Configuration.GetSection("ApprovalThreshold"));
+builder.Services.PostConfigure<ApprovalOptions>(options =>
+{
+    var rawThreshold = builder.Configuration["APPROVAL_THRESHOLD_USD"];
+    if (!string.IsNullOrEmpty(rawThreshold) &&
+        decimal.TryParse(rawThreshold, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var parsedThreshold))
+    {
+        options.ThresholdUsd = parsedThreshold;
+    }
+
+    var rawTimeout = builder.Configuration["APPROVAL_TIMEOUT_HOURS"];
+    if (!string.IsNullOrEmpty(rawTimeout) &&
+        int.TryParse(rawTimeout, out var parsedTimeout) && parsedTimeout > 0)
+    {
+        options.ManualApprovalTimeoutHours = parsedTimeout;
+    }
 });
 
 var app = builder.Build();
@@ -107,6 +130,77 @@ app.MapGet("/workflows/{instanceId}", async (
     return workflowState?.Exists == true
         ? Results.Ok(ToWorkflowStatusResponse(normalizedInstanceId, workflowState))
         : Results.NotFound();
+});
+
+// POST /workflows/{instanceId}/decide — raises the manual-approval event to resume a paused workflow.
+// Called by expense-api approve/reject endpoints via service invocation.
+app.MapPost("/workflows/{instanceId}/decide", async (
+    string instanceId,
+    ManualDecisionRequest decisionRequest,
+    DaprWorkflowClient workflowClient,
+    ILogger<Program> logger,
+    CancellationToken cancellationToken) =>
+{
+    if (string.IsNullOrWhiteSpace(instanceId))
+    {
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["instanceId"] = ["Workflow instance id is required."]
+        });
+    }
+
+    var normalizedInstanceId = instanceId.Trim();
+    var workflowState = await workflowClient.GetWorkflowStateAsync(
+        normalizedInstanceId,
+        getInputsAndOutputs: false,
+        cancellationToken);
+
+    if (workflowState?.Exists != true)
+    {
+        return Results.NotFound();
+    }
+
+    if (!workflowState.IsWorkflowRunning)
+    {
+        return Results.Conflict(new
+        {
+            error = "Workflow is not running and cannot accept a decision.",
+            instanceId = normalizedInstanceId,
+            runtimeStatus = workflowState.RuntimeStatus.ToString()
+        });
+    }
+
+    var reason = string.IsNullOrWhiteSpace(decisionRequest.Reason)
+        ? (decisionRequest.Approved ? null : "Manual rejection by approver")
+        : decisionRequest.Reason;
+
+    var decisionEvent = new ManualDecisionEvent(decisionRequest.Approved, reason);
+
+    try
+    {
+        await workflowClient.RaiseEventAsync(
+            normalizedInstanceId,
+            ExpenseApprovalWorkflow.ManualDecisionEventName,
+            decisionEvent,
+            cancellationToken);
+
+        logger.LogInformation(
+            "Decision '{Decision}' raised for workflow '{InstanceId}'.",
+            decisionRequest.Approved ? "Approved" : "Rejected",
+            normalizedInstanceId);
+
+        return Results.Accepted(
+            $"/workflows/{normalizedInstanceId}",
+            new { instanceId = normalizedInstanceId, decision = decisionRequest.Approved ? "Approved" : "Rejected" });
+    }
+    catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+    {
+        logger.LogError(ex, "Failed to raise decision event for workflow '{InstanceId}'.", normalizedInstanceId);
+        return Results.Problem(
+            title: "Decision could not be submitted.",
+            detail: "The manual decision event could not be raised for this workflow instance.",
+            statusCode: StatusCodes.Status500InternalServerError);
+    }
 });
 
 app.MapGet("/", () => TypedResults.Ok(new WorkflowEngineDescriptor(
@@ -237,5 +331,10 @@ internal sealed record WorkflowStatusResponse(
     ExpenseApprovalWorkflowResult? Output,
     ExpenseSubmission? Input,
     string? FailureDetails);
+
+/// <summary>Request body for the POST /workflows/{instanceId}/decide endpoint.</summary>
+internal sealed record ManualDecisionRequest(
+    bool Approved,
+    string? Reason = null);
 
 public partial class Program;

--- a/src/workflow-engine/Workflows/ExpenseApprovalWorkflow.cs
+++ b/src/workflow-engine/Workflows/ExpenseApprovalWorkflow.cs
@@ -1,12 +1,21 @@
 using RadiusClaim.Contracts;
 using Dapr.Workflow;
+using Microsoft.Extensions.Options;
 using WorkflowEngine.Activities;
 using WorkflowEngine.Models;
 
 namespace WorkflowEngine.Workflows;
 
-internal sealed class ExpenseApprovalWorkflow : Workflow<ExpenseSubmission, ExpenseApprovalWorkflowResult>
+internal sealed class ExpenseApprovalWorkflow(IOptions<ApprovalOptions> approvalOptions)
+    : Workflow<ExpenseSubmission, ExpenseApprovalWorkflowResult>
 {
+    /// <summary>External event name raised by the approve/reject API endpoints.</summary>
+    internal const string ManualDecisionEventName = RadiusClaimDapr.WorkflowEvents.ExpenseDecision;
+
+    private const string ManualApprovalApprovedSource = "ManuallyApprovedByReviewer";
+    private const string ManualApprovalRejectedSource = "ManuallyRejectedByReviewer";
+    private const string ApprovalTimeoutRejectedSource = "AutoRejectedApprovalTimeout";
+
     public override async Task<ExpenseApprovalWorkflowResult> RunAsync(WorkflowContext context, ExpenseSubmission input)
     {
         ArgumentNullException.ThrowIfNull(input);
@@ -18,11 +27,17 @@ internal sealed class ExpenseApprovalWorkflow : Workflow<ExpenseSubmission, Expe
             decision.Status,
             "approval-recorded"));
 
-        var finalStatus = decision.Status;
+        ExpenseStatus finalStatus;
+        NotificationEventType finalEventType;
+        string finalDecisionSource;
+
         if (decision.Status == ExpenseStatus.Approved)
         {
+            // Fast path: auto-approved under threshold.
             await context.CallActivityAsync<bool>(nameof(ProcessReimbursementActivity), input.ExpenseId);
             finalStatus = ExpenseStatus.Reimbursed;
+            finalEventType = NotificationEventType.ExpenseApproved;
+            finalDecisionSource = decision.DecisionSource;
 
             context.SetCustomStatus(new WorkflowProgress(
                 input.ExpenseId,
@@ -30,8 +45,88 @@ internal sealed class ExpenseApprovalWorkflow : Workflow<ExpenseSubmission, Expe
                 finalStatus,
                 "reimbursement-recorded"));
         }
+        else
+        {
+            // Human-in-the-loop path: notify approver, then pause and wait for a decision signal.
+            var reviewNotification = BuildManualReviewNotification(input, context.CurrentUtcDateTime);
+            await context.CallActivityAsync<bool>(nameof(PublishNotificationActivity), reviewNotification);
 
-        var notification = BuildNotification(input, finalStatus, decision, context.CurrentUtcDateTime);
+            context.SetCustomStatus(new WorkflowProgress(
+                input.ExpenseId,
+                input.CorrelationId,
+                ExpenseStatus.ManualReviewRequested,
+                "awaiting-manual-approval"));
+
+            // Race: external decision event vs configurable timeout.
+            var timeoutHours = approvalOptions.Value.ManualApprovalTimeoutHours;
+            var decisionTask = context.WaitForExternalEventAsync<ManualDecisionEvent>(ManualDecisionEventName);
+            var timeoutTask = context.CreateTimer(TimeSpan.FromHours(timeoutHours));
+            var winner = await Task.WhenAny(decisionTask, timeoutTask);
+
+            if (winner == decisionTask)
+            {
+                var manualDecision = await decisionTask;
+                if (manualDecision?.Approved == true)
+                {
+                    // Transition ManualReviewRequested → Approved in state store before reimbursing.
+                    await context.CallActivityAsync<bool>(nameof(RecordApprovalActivity), input.ExpenseId);
+
+                    context.SetCustomStatus(new WorkflowProgress(
+                        input.ExpenseId,
+                        input.CorrelationId,
+                        ExpenseStatus.Approved,
+                        "manually-approved"));
+
+                    await context.CallActivityAsync<bool>(nameof(ProcessReimbursementActivity), input.ExpenseId);
+                    finalStatus = ExpenseStatus.Reimbursed;
+                    finalEventType = NotificationEventType.ExpenseApproved;
+                    finalDecisionSource = ManualApprovalApprovedSource;
+
+                    context.SetCustomStatus(new WorkflowProgress(
+                        input.ExpenseId,
+                        input.CorrelationId,
+                        finalStatus,
+                        "reimbursement-recorded"));
+                }
+                else
+                {
+                    var reason = string.IsNullOrWhiteSpace(manualDecision?.Reason)
+                        ? "Manual rejection by approver"
+                        : manualDecision.Reason;
+
+                    await context.CallActivityAsync<bool>(nameof(RejectExpenseActivity),
+                        new RejectionInput(input.ExpenseId, input.CorrelationId, reason));
+
+                    finalStatus = ExpenseStatus.Rejected;
+                    finalEventType = NotificationEventType.ExpenseRejected;
+                    finalDecisionSource = ManualApprovalRejectedSource;
+
+                    context.SetCustomStatus(new WorkflowProgress(
+                        input.ExpenseId,
+                        input.CorrelationId,
+                        finalStatus,
+                        "rejection-recorded"));
+                }
+            }
+            else
+            {
+                // Timeout expired — auto-reject.
+                await context.CallActivityAsync<bool>(nameof(RejectExpenseActivity),
+                    new RejectionInput(input.ExpenseId, input.CorrelationId, "Auto-rejected: approval timeout exceeded"));
+
+                finalStatus = ExpenseStatus.Rejected;
+                finalEventType = NotificationEventType.ExpenseRejected;
+                finalDecisionSource = ApprovalTimeoutRejectedSource;
+
+                context.SetCustomStatus(new WorkflowProgress(
+                    input.ExpenseId,
+                    input.CorrelationId,
+                    finalStatus,
+                    "rejection-recorded"));
+            }
+        }
+
+        var notification = BuildFinalNotification(input, finalStatus, finalEventType, context.CurrentUtcDateTime);
         await context.CallActivityAsync<bool>(nameof(PublishNotificationActivity), notification);
 
         context.SetCustomStatus(new WorkflowProgress(
@@ -44,19 +139,36 @@ internal sealed class ExpenseApprovalWorkflow : Workflow<ExpenseSubmission, Expe
             input.ExpenseId,
             input.CorrelationId,
             finalStatus,
-            decision.NotificationEventType,
-            decision.DecisionSource);
+            finalEventType,
+            finalDecisionSource);
     }
 
-    private static NotificationRequest BuildNotification(
+    private static NotificationRequest BuildManualReviewNotification(
+        ExpenseSubmission input,
+        DateTime workflowUtcNow)
+    {
+        var occurredAtUtc = new DateTimeOffset(DateTime.SpecifyKind(workflowUtcNow, DateTimeKind.Utc));
+        return new NotificationRequest(
+            input.ExpenseId,
+            input.CorrelationId,
+            input.EmployeeId,
+            "email",
+            NotificationEventType.ManualReviewRequested,
+            $"Expense {input.ExpenseId} needs manual review",
+            $"Expense {input.ExpenseId} is ${input.Amount:F2} and requires approval. " +
+            $"Use POST /expenses/{input.ExpenseId}/approve or /reject to decide.",
+            occurredAtUtc);
+    }
+
+    private static NotificationRequest BuildFinalNotification(
         ExpenseSubmission input,
         ExpenseStatus finalStatus,
-        ApprovalDecision decision,
+        NotificationEventType eventType,
         DateTime workflowUtcNow)
     {
         var occurredAtUtc = new DateTimeOffset(DateTime.SpecifyKind(workflowUtcNow, DateTimeKind.Utc));
 
-        return decision.NotificationEventType switch
+        return eventType switch
         {
             NotificationEventType.ExpenseApproved => new NotificationRequest(
                 input.ExpenseId,
@@ -65,19 +177,20 @@ internal sealed class ExpenseApprovalWorkflow : Workflow<ExpenseSubmission, Expe
                 "email",
                 NotificationEventType.ExpenseApproved,
                 $"Expense {input.ExpenseId} approved",
-                $"Expense {input.ExpenseId} was auto-approved under $100.00 and is now {finalStatus}.",
+                $"Expense {input.ExpenseId} was approved and is now {finalStatus}.",
                 occurredAtUtc),
-            NotificationEventType.ManualReviewRequested => new NotificationRequest(
+            NotificationEventType.ExpenseRejected => new NotificationRequest(
                 input.ExpenseId,
                 input.CorrelationId,
                 input.EmployeeId,
                 "email",
-                NotificationEventType.ManualReviewRequested,
-                $"Expense {input.ExpenseId} needs manual review",
-                $"Expense {input.ExpenseId} is ${input.Amount:F2} and was routed to manual review.",
+                NotificationEventType.ExpenseRejected,
+                $"Expense {input.ExpenseId} rejected",
+                $"Expense {input.ExpenseId} was rejected and is now {finalStatus}.",
                 occurredAtUtc),
             _ => throw new InvalidOperationException(
-                $"Unsupported notification event type '{decision.NotificationEventType}'.")
+                $"Unsupported final notification event type '{eventType}'.")
         };
     }
 }
+

--- a/src/workflow-engine/appsettings.json
+++ b/src/workflow-engine/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApprovalThreshold": {
+    "ThresholdUsd": 100.0,
+    "ManualApprovalTimeoutHours": 48
+  }
 }


### PR DESCRIPTION
## Summary

Add human-in-the-loop to the expense approval workflow. Expenses ≥ $100 now pause and wait for an explicit approve/reject signal before proceeding.

## Changes

### Workflow Engine
- **`RecordApprovalActivity`** — idempotent state transition `ManualReviewRequested → Approved`
- **`RejectExpenseActivity`** — idempotent state transition `ManualReviewRequested → Rejected` (used for both human and timeout rejections)
- **`ExpenseApprovalWorkflow`** — branches on auto vs manual path; pauses with `WaitForExternalEventAsync` raced against a `CreateTimer(48h)` timeout; calls the correct state-transition activity before reimbursement
- **`POST /workflows/{instanceId}/decide`** — raises the `expense-decision` event to resume a paused workflow
- **`ApprovalOptions`** — configurable `ManualApprovalTimeoutHours` (default 48), overridable via `APPROVAL_TIMEOUT_HOURS` env var
- **`ManualDecisionEvent`** / **`RejectionInput`** — typed event/activity payloads

### Expense API
- **`POST /expenses/{id}/approve`** — looks up expense, validates status, forwards signal to workflow-engine
- **`POST /expenses/{id}/reject`** — same, with `approved: false`

### Contracts
- `RadiusClaimDapr.WorkflowEvents.ExpenseDecision` constant for the external event name
- `ExpenseRecord.RejectionReason` optional field

## State Machine
```
Submitted → [auto <$100] → Approved → Reimbursed → ✅
Submitted → [manual ≥$100] → ManualReviewRequested
  → [human approve] → Approved → Reimbursed → ✅
  → [human reject] → Rejected → ❌
  → [timeout 48h] → Rejected → ❌ (auto)
```

## Retry Safety
Every activity is idempotent. Dapr Workflow can retry any step without producing duplicate state transitions.

Closes #1