### PR TITLE
feat(notification): add pluggable transport interface

### DIFF
--- a/.squad/agents/warren/history.md
+++ b/.squad/agents/warren/history.md
@@ -7,6 +7,10 @@
 
 ## Learnings
 
+- **Issue #11 — Notification Transport:** C# compiler CS1593 cascades from switch-expression lambdas with heterogeneous return types when the switch result is passed directly to `AddSingleton<T>(factory)`. Solution: use `if/else` branch with `AddSingleton<TService, TImpl>()` or declare explicit `Func<IServiceProvider, T>` variable before passing. Always use consistent anonymous-object shapes across all lambda return paths to avoid overload resolution failures on `MapPost`.
+- Transport abstraction via `INotificationTransport` interface makes the delivery channel fully swappable without touching the Dapr subscription wiring. The `NOTIFICATION_TRANSPORT` env var (read from `IConfiguration`) is the activation gate; DI wires the correct singleton at startup.
+- Untracked files survive `git stash` (without `--include-untracked`) but NOT `git stash --include-untracked` pop onto a different branch — always use targeted `git checkout stash@{0}^3 -- <paths>` to restore untracked files selectively.
+
 - Added to resolve the remaining Phase 2 deadlock in the `POST /expenses` write path.
 - The sample must stay intentionally small, demoable in roughly ten minutes, and aimed at enterprise/platform audiences.
 - Azure is the current target, but application code must stay cloud-agnostic through Dapr abstractions.
@@ -35,3 +39,16 @@ Warren standardized all `POST /expenses` non-success responses to RFC 7807 probl
 - **Build Status:** ✅ Validated `dotnet build`
 - **Decision:** [Warren: standardize expense submission failure payloads](../decisions/decisions.md)
 - **Completed:** 2026-03-25T14:28:31Z
+
+## 2026-03-27: Notification Transport (Issue #11, COMPLETE)
+
+Added pluggable transport interface to `notification-svc`:
+
+- **`INotificationTransport`** — interface with `TransportName` and `SendAsync`
+- **`LoggingTransport`** — default; serializes full payload as structured JSON via `logger.LogInformation`
+- **`EmailTransport`** — stub; logs all fields as if dispatching SMTP (safe in demo/CI, marked with TODO for real relay)
+- **DI wiring** — `if (transportName == "email")` branch in `Program.cs` registers the correct singleton at startup; `NOTIFICATION_TRANSPORT` env var read via `IConfiguration`
+- **16 tests** — `LoggingTransportTests`, `EmailTransportTests`, `TransportDispatchTests` covering transport names, `SendAsync` completion, all event types, dispatch routing, interface conformance
+- **Files:** `src/notification-svc/Transports/INotificationTransport.cs`, `LoggingTransport.cs`, `EmailTransport.cs`, `src/notification-svc/Program.cs`, `src/NotificationSvc.Tests/`
+- **Build:** ✅ `dotnet build` succeeds; `dotnet test` — 16/16 passed
+- **PR:** draft — squad/11-notification-transport → Closes #11

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -2875,3 +2875,37 @@ Operators who muscle-memory `--workspace-name` from bootstrap will silently get 
 - Files affected: bootstrap.sh, teardown.sh, deploy-dapr-components.sh, deploy-dapr-components-workload-identity.sh, publish-radius-recipes.sh, scripts/README.md
 
 **Merged from inbox:** 2026-03-27T09:05:00Z
+
+---
+
+## 9. Pluggable Notification Transport (Issue #11)
+
+**By:** Warren (Eventing Specialist)
+**Date:** 2026-03-27
+**Status:** IMPLEMENTED — PR squad/11-notification-transport, Closes #11
+
+### What
+
+Introduced `INotificationTransport` interface with two implementations in `notification-svc`:
+
+| Transport | `NOTIFICATION_TRANSPORT` value | Behaviour |
+|-----------|-------------------------------|-----------|
+| `LoggingTransport` | `log` (default) | Full `NotificationRequest` serialised as structured JSON log event |
+| `EmailTransport` | `email` | Structured log per field (stub — TODO wire real SMTP relay) |
+
+### Design Choices
+
+- Interface-first so any transport (SMS, webhook, SendGrid) can be wired without changing the handler or Dapr subscription.
+- `AddSingleton<TService, TImpl>()` (if/else) used instead of switch-expression factory to avoid C# CS1593 overload cascade.
+- Service-locator (`request.HttpContext.RequestServices`) used inside `[Topic]` lambda because Dapr's attribute approach limits the lambda to ≤3 special params before hitting `RequestDelegate` overload conflict.
+- All lambda return paths use the same anonymous type shape (`new { status = "..." }`) to avoid inference failures.
+- `NOTIFICATION_TRANSPORT` read via `IConfiguration` — overridable via env, appsettings, or Dapr secrets.
+- 16 xunit tests cover transport names, `SendAsync`, all event types, and DI dispatch routing.
+
+### Ordering & Delivery
+
+- Dapr at-least-once; handler returns `200 OK` for both `delivered` and `ignored` to suppress dead-letter retry.
+- Transport stubs are synchronous no-ops; no ordering guarantees at this phase.
+- Dead-letter handling and replay deferred to a future issue.
+
+**Merged from inbox:** 2026-03-27

--- a/RadiusClaim.slnx
+++ b/RadiusClaim.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/WorkflowEngine.Tests/WorkflowEngine.Tests.csproj" />
+    <Project Path="src/NotificationSvc.Tests/NotificationSvc.Tests.csproj" />
   </Folder>
   <Folder Name="/src/expense-api/">
     <Project Path="src/expense-api/ExpenseApi.csproj" />
@@ -13,6 +14,5 @@
   </Folder>
   <Folder Name="/src/workflow-engine/">
     <Project Path="src/workflow-engine/WorkflowEngine.csproj" />
-    <Project Path="src/WorkflowEngine.Tests/WorkflowEngine.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/NotificationSvc.Tests/NotificationSvc.Tests.csproj
+++ b/src/NotificationSvc.Tests/NotificationSvc.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../notification-svc/NotificationSvc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NotificationSvc.Tests/Transports/EmailTransportTests.cs
+++ b/src/NotificationSvc.Tests/Transports/EmailTransportTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NotificationSvc.Transports;
+using RadiusClaim.Contracts;
+using Xunit;
+
+namespace NotificationSvc.Tests.Transports;
+
+public sealed class EmailTransportTests
+{
+    private static NotificationRequest BuildNotification(
+        string recipient = "bob@example.com",
+        NotificationEventType eventType = NotificationEventType.ExpenseRejected) => new(
+        ExpenseId: "exp-42",
+        CorrelationId: "corr-42",
+        Recipient: recipient,
+        Channel: "email",
+        EventType: eventType,
+        Subject: "Expense decision",
+        Message: "Your expense was processed.",
+        OccurredAtUtc: DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void TransportName_IsEmail()
+    {
+        var transport = new EmailTransport(NullLogger<EmailTransport>.Instance);
+        Assert.Equal("email", transport.TransportName);
+    }
+
+    [Fact]
+    public async Task SendAsync_ValidNotification_CompletesSuccessfully()
+    {
+        var transport = new EmailTransport(NullLogger<EmailTransport>.Instance);
+        await transport.SendAsync(BuildNotification());
+    }
+
+    [Fact]
+    public async Task SendAsync_SupportsCancellation()
+    {
+        var transport = new EmailTransport(NullLogger<EmailTransport>.Instance);
+        using var cts = new CancellationTokenSource();
+        await transport.SendAsync(BuildNotification(), cts.Token);
+    }
+
+    [Theory]
+    [InlineData(NotificationEventType.ExpenseApproved)]
+    [InlineData(NotificationEventType.ExpenseRejected)]
+    [InlineData(NotificationEventType.ManualReviewRequested)]
+    public async Task SendAsync_AllEventTypes_CompletesWithoutError(NotificationEventType eventType)
+    {
+        var transport = new EmailTransport(NullLogger<EmailTransport>.Instance);
+        await transport.SendAsync(BuildNotification(eventType: eventType));
+    }
+}

--- a/src/NotificationSvc.Tests/Transports/LoggingTransportTests.cs
+++ b/src/NotificationSvc.Tests/Transports/LoggingTransportTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NotificationSvc.Transports;
+using RadiusClaim.Contracts;
+using Xunit;
+
+namespace NotificationSvc.Tests.Transports;
+
+public sealed class LoggingTransportTests
+{
+    private static NotificationRequest BuildNotification() => new(
+        ExpenseId: "exp-1",
+        CorrelationId: "corr-1",
+        Recipient: "alice@example.com",
+        Channel: "email",
+        EventType: NotificationEventType.ExpenseApproved,
+        Subject: "Expense approved",
+        Message: "Your expense of $50 was approved.",
+        OccurredAtUtc: DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void TransportName_IsLog()
+    {
+        var transport = new LoggingTransport(NullLogger<LoggingTransport>.Instance);
+        Assert.Equal("log", transport.TransportName);
+    }
+
+    [Fact]
+    public async Task SendAsync_ValidNotification_CompletesSuccessfully()
+    {
+        var transport = new LoggingTransport(NullLogger<LoggingTransport>.Instance);
+        // Should not throw
+        await transport.SendAsync(BuildNotification());
+    }
+
+    [Fact]
+    public async Task SendAsync_SupportsCancellation()
+    {
+        var transport = new LoggingTransport(NullLogger<LoggingTransport>.Instance);
+        using var cts = new CancellationTokenSource();
+        await transport.SendAsync(BuildNotification(), cts.Token);
+    }
+}

--- a/src/NotificationSvc.Tests/Transports/TransportDispatchTests.cs
+++ b/src/NotificationSvc.Tests/Transports/TransportDispatchTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NotificationSvc.Transports;
+using Xunit;
+
+namespace NotificationSvc.Tests.Transports;
+
+/// <summary>
+/// Tests the DI wiring logic: that the correct transport is registered
+/// based on the NOTIFICATION_TRANSPORT configuration value.
+/// </summary>
+public sealed class TransportDispatchTests
+{
+    private static INotificationTransport ResolveTransport(string? envValue)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var transportName = envValue ?? "log";
+        if (transportName == "email")
+            services.AddSingleton<INotificationTransport, EmailTransport>();
+        else
+            services.AddSingleton<INotificationTransport, LoggingTransport>();
+
+        using var sp = services.BuildServiceProvider();
+        return sp.GetRequiredService<INotificationTransport>();
+    }
+
+    [Theory]
+    [InlineData(null,    "log")]
+    [InlineData("",      "log")]
+    [InlineData("log",   "log")]
+    [InlineData("other", "log")]
+    public void DefaultAndUnknown_ResolvesToLoggingTransport(string? envValue, string expectedName)
+    {
+        var transport = ResolveTransport(envValue);
+        Assert.IsType<LoggingTransport>(transport);
+        Assert.Equal(expectedName, transport.TransportName);
+    }
+
+    [Fact]
+    public void EmailValue_ResolvesToEmailTransport()
+    {
+        var transport = ResolveTransport("email");
+        Assert.IsType<EmailTransport>(transport);
+        Assert.Equal("email", transport.TransportName);
+    }
+
+    [Fact]
+    public void LoggingTransport_ImplementsInterface()
+    {
+        var transport = ResolveTransport("log");
+        Assert.IsAssignableFrom<INotificationTransport>(transport);
+    }
+
+    [Fact]
+    public void EmailTransport_ImplementsInterface()
+    {
+        var transport = ResolveTransport("email");
+        Assert.IsAssignableFrom<INotificationTransport>(transport);
+    }
+}

--- a/src/notification-svc/Program.cs
+++ b/src/notification-svc/Program.cs
@@ -2,10 +2,17 @@ using System.Text.Json;
 using RadiusClaim.Contracts;
 using Dapr;
 using Dapr.Client;
+using NotificationSvc.Transports;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDaprClient();
+
+var transportName = builder.Configuration["NOTIFICATION_TRANSPORT"] ?? "log";
+if (transportName == "email")
+    builder.Services.AddSingleton<INotificationTransport, EmailTransport>();
+else
+    builder.Services.AddSingleton<INotificationTransport, LoggingTransport>();
 
 var app = builder.Build();
 
@@ -14,15 +21,17 @@ app.MapSubscribeHandler();
 
 app.MapGet("/", () => TypedResults.Ok(new ServiceDescriptor(
     RadiusClaimDapr.AppIds.NotificationService,
-    "phase-4",
+    "phase-5",
     [nameof(NotificationRequest)],
     ["pubsub"],
-    "Dapr pub/sub delivery is now visible via structured notification logs; transports stay deferred.")));
+    "Pluggable transport: set NOTIFICATION_TRANSPORT=log (default) or NOTIFICATION_TRANSPORT=email")));
 
 app.MapPost("/notifications",
     [Topic(RadiusClaimDapr.Components.PubSub, RadiusClaimDapr.Topics.ExpenseNotifications)]
     async (HttpRequest request, ILogger<Program> logger, CancellationToken cancellationToken) =>
     {
+        var transport = request.HttpContext.RequestServices.GetRequiredService<INotificationTransport>();
+
         NotificationRequest? notification;
 
         try
@@ -48,15 +57,10 @@ app.MapPost("/notifications",
             return TypedResults.Ok(new { status = "ignored" });
         }
 
-        logger.LogInformation(
-            "Notification received: EventType={EventType}, ExpenseId={ExpenseId}, CorrelationId={CorrelationId}, Recipient={Recipient}, Subject={Subject}",
-            notification.EventType,
-            notification.ExpenseId,
-            notification.CorrelationId,
-            notification.Recipient,
-            notification.Subject);
+        await transport.SendAsync(notification, cancellationToken);
 
-        return TypedResults.Ok(new { status = "received" });
+        // Return consistent anonymous type to keep lambda return type inference stable.
+        return TypedResults.Ok(new { status = "delivered" });
     });
 
 app.MapGet("/healthz", () => TypedResults.Ok(new { status = "ok" }));

--- a/src/notification-svc/Transports/EmailTransport.cs
+++ b/src/notification-svc/Transports/EmailTransport.cs
@@ -1,0 +1,30 @@
+using RadiusClaim.Contracts;
+
+namespace NotificationSvc.Transports;
+
+/// <summary>
+/// Stubbed email transport.  In production this would construct and dispatch an SMTP message
+/// (or call a SendGrid-style SDK).  The stub logs intent without opening a real connection,
+/// making it safe to run in demo and CI environments without an SMTP relay.
+/// </summary>
+public sealed class EmailTransport(ILogger<EmailTransport> logger) : INotificationTransport
+{
+    public string TransportName => "email";
+
+    public Task SendAsync(NotificationRequest notification, CancellationToken cancellationToken = default)
+    {
+        // TODO: replace with real SMTP/SendGrid call when relay is configured.
+        logger.LogInformation(
+            "NOTIFICATION_DELIVERED transport={Transport} to={Recipient} subject={Subject} eventType={EventType} expenseId={ExpenseId} correlationId={CorrelationId} channel={Channel} occurredAtUtc={OccurredAtUtc}",
+            TransportName,
+            notification.Recipient,
+            notification.Subject,
+            notification.EventType,
+            notification.ExpenseId,
+            notification.CorrelationId,
+            notification.Channel,
+            notification.OccurredAtUtc);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/notification-svc/Transports/INotificationTransport.cs
+++ b/src/notification-svc/Transports/INotificationTransport.cs
@@ -1,0 +1,15 @@
+using RadiusClaim.Contracts;
+
+namespace NotificationSvc.Transports;
+
+/// <summary>
+/// Pluggable delivery channel for outbound notifications.
+/// Selected at startup via the NOTIFICATION_TRANSPORT environment variable.
+/// </summary>
+public interface INotificationTransport
+{
+    /// <summary>Identifies the active transport for observability.</summary>
+    string TransportName { get; }
+
+    Task SendAsync(NotificationRequest notification, CancellationToken cancellationToken = default);
+}

--- a/src/notification-svc/Transports/LoggingTransport.cs
+++ b/src/notification-svc/Transports/LoggingTransport.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using RadiusClaim.Contracts;
+
+namespace NotificationSvc.Transports;
+
+/// <summary>
+/// Default transport: emits the notification as a structured JSON event to the application log.
+/// Useful in demos and local development where no SMTP relay is configured.
+/// </summary>
+public sealed class LoggingTransport(ILogger<LoggingTransport> logger) : INotificationTransport
+{
+    public string TransportName => "log";
+
+    public Task SendAsync(NotificationRequest notification, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation(
+            "NOTIFICATION_DELIVERED transport={Transport} payload={Payload}",
+            TransportName,
+            JsonSerializer.Serialize(notification));
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #11

Adds a real (demo-friendly) pluggable transport to `notification-svc`.

## Changes

| File | Change |
|------|--------|
| `src/notification-svc/Transports/INotificationTransport.cs` | New — `TransportName` + `SendAsync` contract |
| `src/notification-svc/Transports/LoggingTransport.cs` | New — full payload serialised as structured JSON log (`log` transport) |
| `src/notification-svc/Transports/EmailTransport.cs` | New — per-field structured log stub; TODO wire real SMTP (`email` transport) |
| `src/notification-svc/Program.cs` | DI wiring based on `NOTIFICATION_TRANSPORT` env var; response updated to `delivered` |
| `src/NotificationSvc.Tests/` | New test project — 16 xunit tests |
| `RadiusClaim.slnx` | Added `NotificationSvc.Tests` project |

## Transport Selection

Set `NOTIFICATION_TRANSPORT=email` to activate the email stub. Defaults to `log`.

## Tests

```
Passed! - Failed: 0, Passed: 16, Skipped: 0, Total: 16
```

## Notes

- `AddSingleton<TService, TImpl>()` if/else used (not switch-expression factory) to avoid C# CS1593 cascade from switch-arm lambda type inference.
- Service-locator inside `[Topic]` lambda because Dapr attribute limits handler to ≤3 special params.