### PR TITLE
feat(recipes): add local/dev Radius recipes (Redis, RabbitMQ)

### DIFF
--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,192 @@
+# Local Development Guide
+
+This guide covers running RadiusClaim locally using Radius with **in-cluster components** — no Azure subscription required.
+
+## Overview
+
+RadiusClaim uses Radius recipes to abstract its Dapr components. Two recipe sets are available:
+
+| Environment | State store | Pub/sub | Secrets |
+|---|---|---|---|
+| `azure` / `dev` | Azure Blob Storage | Azure Service Bus | Azure Key Vault |
+| `local` | Redis (in-cluster) | RabbitMQ (in-cluster) | Kubernetes secrets |
+
+Switching between them is a single parameter change at deploy time. The application code is unchanged.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) or equivalent container runtime
+- [kind](https://kind.sigs.k8s.io/) or [k3d](https://k3d.io/) for a local Kubernetes cluster
+- [Radius CLI](https://docs.radapp.io/getting-started/) (`rad`)
+- [Helm](https://helm.sh/) for installing Redis and RabbitMQ
+- [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
+
+## 1 — Cluster Setup
+
+```bash
+# Create a local cluster (kind example)
+kind create cluster --name radiusclaim
+
+# Install Radius
+rad install kubernetes
+
+# Install Dapr
+dapr init --kubernetes --wait
+```
+
+## 2 — Install In-Cluster Dependencies
+
+The local recipes point to Redis and RabbitMQ by their Kubernetes service names. Install both with Helm:
+
+```bash
+# Redis — state store backend
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+helm install redis bitnami/redis \
+  --namespace default \
+  --set auth.enabled=false \
+  --set replica.replicaCount=0
+
+# RabbitMQ — pub/sub backend
+helm install rabbitmq bitnami/rabbitmq \
+  --namespace default \
+  --set auth.username=guest \
+  --set auth.password=guest
+```
+
+The local recipes default to:
+- Redis: `redis-master.default.svc.cluster.local:6379`
+- RabbitMQ: `amqp://guest@rabbitmq.default.svc.cluster.local:5672`
+
+Override `redisServiceName`, `redisNamespace`, `rabbitmqServiceName`, or `rabbitmqNamespace` in `local.parameters.json` if your Helm release names differ.
+
+## 3 — Publish Local Recipes
+
+Local recipes must be pushed to a container registry accessible from your cluster. For local clusters, use a registry bundled with kind/k3d:
+
+```bash
+# k3d example — creates cluster + registry in one step
+k3d cluster create radiusclaim --registry-create radiusclaim-registry:5000
+
+# Push local recipe images
+az bicep publish \
+  --file infra/radius/recipes/local/state-store.bicep \
+  --target br:localhost:5000/recipes/local/state-store:latest
+
+az bicep publish \
+  --file infra/radius/recipes/local/pubsub.bicep \
+  --target br:localhost:5000/recipes/local/pubsub:latest
+
+az bicep publish \
+  --file infra/radius/recipes/local/secrets.bicep \
+  --target br:localhost:5000/recipes/local/secrets:latest
+```
+
+Then update `infra/radius/environments/local.parameters.json`:
+
+```json
+{
+  "recipeRegistry": { "value": "localhost:5000/recipes/local" }
+}
+```
+
+For CI environments using kind with GHCR access, you can keep the default `ghcr.io/wesback/radiusclaim/recipes/local` registry and publish recipes as part of the workflow.
+
+## 4 — Deploy the Local Environment
+
+```bash
+# Register the local Radius environment
+rad deploy infra/radius/environments/local.bicep \
+  --parameters @infra/radius/environments/local.parameters.json
+
+# Deploy the application using local recipe selections
+rad deploy infra/radius/app.bicep \
+  --environment local \
+  --parameters containerRegistry=ghcr.io/wesback/radiusclaim \
+  --parameters imageTag=dev \
+  --parameters deploymentTarget=local \
+  --parameters daprBackings='{"stateStore":{"recipeName":"local-redis-state","parameters":{}},"pubsub":{"recipeName":"local-rabbitmq-pubsub","parameters":{}},"secretStore":{"recipeName":"local-k8s-secrets","parameters":{}}}'
+```
+
+### Using a Parameters File
+
+Create `infra/radius/app.local.parameters.json`:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "containerRegistry": { "value": "ghcr.io/wesback/radiusclaim" },
+    "imageTag": { "value": "dev" },
+    "deploymentTarget": { "value": "local" },
+    "daprBackings": {
+      "value": {
+        "stateStore": { "recipeName": "local-redis-state", "parameters": {} },
+        "pubsub":     { "recipeName": "local-rabbitmq-pubsub", "parameters": {} },
+        "secretStore": { "recipeName": "local-k8s-secrets", "parameters": {} }
+      }
+    }
+  }
+}
+```
+
+Then deploy with:
+
+```bash
+rad deploy infra/radius/app.bicep \
+  --environment local \
+  --parameters @infra/radius/app.local.parameters.json
+```
+
+## 5 — Kubernetes Secrets for Local Secret Store
+
+The `local-k8s-secrets` recipe uses `secretstores.kubernetes` — Dapr reads secrets directly from Kubernetes in the pod's namespace. Create secrets the same way you'd create any Kubernetes secret:
+
+```bash
+kubectl create secret generic my-app-secret \
+  --namespace radiusclaim-local \
+  --from-literal=api-key=my-local-value
+```
+
+Application code accesses secrets through the Dapr secret API with the Kubernetes secret name and key.
+
+## 6 — Verify the Deployment
+
+```bash
+# Check Radius environment
+rad env show local
+
+# List application resources
+rad resource list Applications.Dapr/stateStores --application radiusclaim
+rad resource list Applications.Dapr/pubSubBrokers --application radiusclaim
+rad resource list Applications.Dapr/secretStores --application radiusclaim
+
+# Check Dapr components loaded correctly
+kubectl get components -n radiusclaim-local
+
+# Check pod health
+kubectl get pods -n radiusclaim-local
+```
+
+## Switching Back to Azure
+
+To run against Azure resources, use the `dev` or `azure-radius` environment without overriding `daprBackings`:
+
+```bash
+rad deploy infra/radius/app.bicep \
+  --environment dev \
+  --parameters @infra/radius/dev.parameters.json
+```
+
+The `daprBackings` default in `app.bicep` points to Azure recipes — no additional flags needed.
+
+## Troubleshooting
+
+**Redis connection refused**: Confirm the Helm release name matches `redisServiceName` in `local.parameters.json`. Check with `kubectl get svc -n default | grep redis`.
+
+**RabbitMQ auth errors**: The local recipe defaults to `guest` user and no password secret. If you installed RabbitMQ with a different username, set `rabbitmqUser` in `pubsub.bicep` or pass a custom parameters object via `daprBackings.pubsub.parameters`.
+
+**Recipe template not found**: Ensure you've published the local recipe OCI artifacts to the registry configured in `local.parameters.json`. Run `az bicep publish` for all three recipes.
+
+**Dapr component not loading**: Run `kubectl describe component statestore -n radiusclaim-local` for the full error. Common cause is the recipe outputting a Dapr component type (`state.redis`) that doesn't match the installed Dapr version.

--- a/infra/radius/app.bicep
+++ b/infra/radius/app.bicep
@@ -27,7 +27,20 @@ param useWorkloadIdentity string = 'false'
 @description('Name of the imagePullSecret in the workload namespace for pulling GHCR private images. Leave empty to skip imagePullSecrets injection.')
 param ghcrImagePullRef string = ''
 
-@description('Logical Dapr recipe selections. Override these per environment to swap providers without renaming statestore, pubsub, or platform-secrets.')
+@description('''
+Logical Dapr recipe selections. Override these per environment to swap providers without
+renaming statestore, pubsub, or platform-secrets.
+
+Each entry accepts an optional "parameters" object. When present, those parameters are
+passed verbatim to the recipe (useful for local/in-cluster recipes that ignore Azure names).
+When absent, computed Azure-specific defaults are passed (backwards-compatible).
+
+Azure example (default):
+  { stateStore: { recipeName: 'azure-blob-state' }, ... }
+
+Local/in-cluster example:
+  { stateStore: { recipeName: 'local-redis-state', parameters: {} }, ... }
+''')
 param daprBackings object = {
   stateStore: {
     recipeName: 'azure-blob-state'
@@ -51,6 +64,32 @@ var secretVaultName = 'ce-${take(uniqueString(applicationName, environment, 'pla
 var stateStoreBacking = daprBackings.stateStore
 var pubsubBacking = daprBackings.pubsub
 var secretStoreBacking = daprBackings.secretStore
+
+// Azure-computed defaults for each backing. Used when daprBackings.*.parameters is absent.
+var defaultStateStoreParams = {
+  storageAccountName: stateStoreAccountName
+  containerName: stateStoreContainerName
+}
+var defaultPubsubParams = {
+  namespaceName: pubsubNamespaceName
+  topicName: notificationTopicName
+  subscriptionName: notificationSubscriptionName
+}
+var defaultSecretStoreParams = {
+  vaultName: secretVaultName
+}
+
+// When the backing includes explicit parameters (e.g., local recipes), use them verbatim.
+// Otherwise fall back to the Azure-computed defaults to preserve backwards compatibility.
+var stateStoreRecipeParams = contains(stateStoreBacking, 'parameters')
+  ? stateStoreBacking.parameters
+  : defaultStateStoreParams
+var pubsubRecipeParams = contains(pubsubBacking, 'parameters')
+  ? pubsubBacking.parameters
+  : defaultPubsubParams
+var secretStoreRecipeParams = contains(secretStoreBacking, 'parameters')
+  ? secretStoreBacking.parameters
+  : defaultSecretStoreParams
 var workloadIdentityPodLabels = useWorkloadIdentity == 'true' ? { 'azure.workload.identity/use': 'true' } : {}
 var pullSecrets = empty(ghcrImagePullRef) ? [] : [{ name: ghcrImagePullRef }]
 var publicGatewayHost = empty(publicGatewayHostname)
@@ -78,10 +117,7 @@ resource stateStore 'Applications.Dapr/stateStores@2023-10-01-preview' = {
     resourceProvisioning: 'recipe'
     recipe: {
       name: stateStoreBacking.recipeName
-      parameters: {
-        storageAccountName: stateStoreAccountName
-        containerName: stateStoreContainerName
-      }
+      parameters: stateStoreRecipeParams
     }
   }
 }
@@ -95,11 +131,7 @@ resource pubsub 'Applications.Dapr/pubSubBrokers@2023-10-01-preview' = {
     resourceProvisioning: 'recipe'
     recipe: {
       name: pubsubBacking.recipeName
-      parameters: {
-        namespaceName: pubsubNamespaceName
-        topicName: notificationTopicName
-        subscriptionName: notificationSubscriptionName
-      }
+      parameters: pubsubRecipeParams
     }
   }
 }
@@ -113,9 +145,7 @@ resource platformSecretStore 'Applications.Dapr/secretStores@2023-10-01-preview'
     resourceProvisioning: 'recipe'
     recipe: {
       name: secretStoreBacking.recipeName
-      parameters: {
-        vaultName: secretVaultName
-      }
+      parameters: secretStoreRecipeParams
     }
   }
 }

--- a/infra/radius/environments/local.bicep
+++ b/infra/radius/environments/local.bicep
@@ -1,0 +1,81 @@
+extension radius
+
+@description('Radius local environment name.')
+param environmentName string = 'local'
+
+@description('Kubernetes namespace used for the local Radius development slice.')
+param kubernetesNamespace string = 'radiusclaim-local'
+
+@description('OCI registry prefix that stores published Radius local recipe artifacts.')
+param recipeRegistry string = 'ghcr.io/wesback/radiusclaim/recipes/local'
+
+@description('OCI tag used when resolving Radius local recipe artifacts.')
+param recipeTag string = 'latest'
+
+@description('Kubernetes namespace where Redis is deployed.')
+param redisNamespace string = 'default'
+
+@description('Redis service name within the cluster.')
+param redisServiceName string = 'redis-master'
+
+@description('Kubernetes namespace where RabbitMQ is deployed.')
+param rabbitmqNamespace string = 'default'
+
+@description('RabbitMQ service name within the cluster.')
+param rabbitmqServiceName string = 'rabbitmq'
+
+resource env 'Applications.Core/environments@2023-10-01-preview' = {
+  name: environmentName
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: kubernetesNamespace
+    }
+    // No Azure provider — local recipes run entirely in-cluster.
+    recipes: {
+      'Applications.Dapr/stateStores': {
+        'local-redis-state': {
+          templateKind: 'bicep'
+          templatePath: '${recipeRegistry}/state-store:${recipeTag}'
+          parameters: {
+            redisNamespace: redisNamespace
+            redisServiceName: redisServiceName
+          }
+        }
+      }
+      'Applications.Dapr/pubSubBrokers': {
+        'local-rabbitmq-pubsub': {
+          templateKind: 'bicep'
+          templatePath: '${recipeRegistry}/pubsub:${recipeTag}'
+          parameters: {
+            rabbitmqNamespace: rabbitmqNamespace
+            rabbitmqServiceName: rabbitmqServiceName
+          }
+        }
+      }
+      'Applications.Dapr/secretStores': {
+        'local-k8s-secrets': {
+          templateKind: 'bicep'
+          templatePath: '${recipeRegistry}/secrets:${recipeTag}'
+        }
+      }
+    }
+  }
+}
+
+output environmentModel object = {
+  name: env.name
+  computeTarget: 'local-kubernetes'
+  namespace: kubernetesNamespace
+  recipeArtifacts: {
+    registry: recipeRegistry
+    tag: recipeTag
+  }
+  recipes: {
+    stateStore: 'local-redis-state'
+    pubsub: 'local-rabbitmq-pubsub'
+    secretStore: 'local-k8s-secrets'
+  }
+  note: 'No Azure provider configured. All Dapr components resolve to in-cluster Redis, RabbitMQ, and Kubernetes secrets.'
+}

--- a/infra/radius/environments/local.parameters.json
+++ b/infra/radius/environments/local.parameters.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "local"
+    },
+    "kubernetesNamespace": {
+      "value": "radiusclaim-local"
+    },
+    "recipeRegistry": {
+      "value": "ghcr.io/wesback/radiusclaim/recipes/local"
+    },
+    "recipeTag": {
+      "value": "latest"
+    },
+    "redisNamespace": {
+      "value": "default"
+    },
+    "redisServiceName": {
+      "value": "redis-master"
+    },
+    "rabbitmqNamespace": {
+      "value": "default"
+    },
+    "rabbitmqServiceName": {
+      "value": "rabbitmq"
+    }
+  }
+}

--- a/infra/radius/recipes/local/pubsub.bicep
+++ b/infra/radius/recipes/local/pubsub.bicep
@@ -1,0 +1,53 @@
+@description('Radius-provided object containing information about the resource calling the Recipe.')
+param context object
+
+@description('Kubernetes namespace where RabbitMQ is deployed.')
+param rabbitmqNamespace string = 'default'
+
+@description('RabbitMQ service name within the cluster.')
+param rabbitmqServiceName string = 'rabbitmq'
+
+@description('RabbitMQ AMQP port.')
+param rabbitmqPort int = 5672
+
+@description('RabbitMQ username.')
+param rabbitmqUser string = 'guest'
+
+@description('Name of the Kubernetes secret holding the RabbitMQ password.')
+param rabbitmqPasswordSecretName string = ''
+
+@description('Key within the Kubernetes secret for the RabbitMQ password.')
+param rabbitmqPasswordSecretKey string = 'rabbitmq-password'
+
+// Suppress unused-param warning — context is required by Radius but not consumed by in-cluster recipes.
+var _ = context
+
+var host = 'amqp://${rabbitmqUser}@${rabbitmqServiceName}.${rabbitmqNamespace}.svc.cluster.local:${rabbitmqPort}'
+
+var baseMetadata = {
+  host: { value: host }
+  durable: { value: 'true' }
+  deletedWhenUnused: { value: 'false' }
+  autoAck: { value: 'false' }
+  reconnectWait: { value: '0' }
+  concurrency: { value: 'parallel' }
+}
+
+var authMetadata = empty(rabbitmqPasswordSecretName)
+  ? {}
+  : {
+      password: {
+        secretKeyRef: {
+          name: rabbitmqPasswordSecretName
+          key: rabbitmqPasswordSecretKey
+        }
+      }
+    }
+
+output result object = {
+  values: {
+    type: 'pubsub.rabbitmq'
+    version: 'v1'
+    metadata: union(baseMetadata, authMetadata)
+  }
+}

--- a/infra/radius/recipes/local/secrets.bicep
+++ b/infra/radius/recipes/local/secrets.bicep
@@ -1,0 +1,15 @@
+@description('Radius-provided object containing information about the resource calling the Recipe.')
+param context object
+
+// Suppress unused-param warning — context is required by Radius but not consumed by in-cluster recipes.
+var _ = context
+
+// secretstores.kubernetes reads directly from Kubernetes secrets in the pod namespace.
+// No backing infrastructure is provisioned and no metadata is required.
+output result object = {
+  values: {
+    type: 'secretstores.kubernetes'
+    version: 'v1'
+    metadata: {}
+  }
+}

--- a/infra/radius/recipes/local/state-store.bicep
+++ b/infra/radius/recipes/local/state-store.bicep
@@ -1,0 +1,46 @@
+@description('Radius-provided object containing information about the resource calling the Recipe.')
+param context object
+
+@description('Kubernetes namespace where Redis is deployed.')
+param redisNamespace string = 'default'
+
+@description('Redis service name within the cluster.')
+param redisServiceName string = 'redis-master'
+
+@description('Redis port.')
+param redisPort int = 6379
+
+@description('Name of the Kubernetes secret holding the Redis password. Leave empty for unauthenticated Redis.')
+param redisPasswordSecretName string = ''
+
+@description('Key within the Kubernetes secret for the Redis password.')
+param redisPasswordSecretKey string = 'redis-password'
+
+// Suppress unused-param warning — context is required by Radius but not consumed by in-cluster recipes.
+var _ = context
+
+var redisHost = '${redisServiceName}.${redisNamespace}.svc.cluster.local:${redisPort}'
+
+var baseMetadata = {
+  redisHost: { value: redisHost }
+  actorStateStore: { value: 'true' }
+}
+
+var authMetadata = empty(redisPasswordSecretName)
+  ? {}
+  : {
+      redisPassword: {
+        secretKeyRef: {
+          name: redisPasswordSecretName
+          key: redisPasswordSecretKey
+        }
+      }
+    }
+
+output result object = {
+  values: {
+    type: 'state.redis'
+    version: 'v1'
+    metadata: union(baseMetadata, authMetadata)
+  }
+}


### PR DESCRIPTION
## Summary

Add local environment recipes for development without Azure credentials. Closes #13.

## Changes

### New: `infra/radius/recipes/local/`
- `state-store.bicep` — Redis-based Dapr state store (`state.redis`)
- `pubsub.bicep` — RabbitMQ-based Dapr pub/sub (`pubsub.rabbitmq`)  
- `secrets.bicep` — Kubernetes-native secret store (`secretstores.kubernetes`)

### New: `infra/radius/environments/local.bicep`
Local Radius environment with no Azure provider. Registers the three local recipes. Fully parameterized (Redis/RabbitMQ namespace and service name).

### Updated: `infra/radius/app.bicep`
`daprBackings` now supports an optional `parameters` field per backing. When present, those parameters are passed verbatim to the recipe — enabling local recipes that don't accept Azure-specific names. Azure path is backwards-compatible (no `parameters` key → computed Azure defaults used as before).

### New: `docs/local-dev.md`
Full walkthrough: cluster setup, Helm installs for Redis/RabbitMQ, recipe publishing, deploy commands, and troubleshooting.

## How to Switch Environments

| Target | Environment flag | `daprBackings.stateStore.recipeName` |
|---|---|---|
| Azure (default) | `--environment dev` | `azure-blob-state` |
| Local / CI | `--environment local` | `local-redis-state` |

No application code changes required.