### PR TITLE
feat(ui): add minimal workflow monitoring dashboard

### DIFF
--- a/.squad/agents/camila/history.md
+++ b/.squad/agents/camila/history.md
@@ -25,3 +25,12 @@
 - Rationale: UI is demo surface, not product; framework adds pedagogical friction without advancing Dapr + Radius narrative
 - **Implication for React recommendation:** Document React path for future reference; maintain vanilla JS as the appropriate choice for Phase 7
 - **Status:** React recommendation is documented and ready for team; vanilla is the current path forward
+
+## Learnings (Issue #15 — Monitoring Dashboard, 2026-03-27)
+
+- Issue #15 asked for a workflow monitoring dashboard; the existing `wwwroot/app/` UI already covered items 1–3 (expense list with status, timeline/history, auto-refresh).
+- The missing piece was approve/reject buttons for `ManualReviewRequested` expenses. Added `handleApproval()` in `app.js` that POSTs to `/expenses/{id}/approve` or `/expenses/{id}/reject`.
+- Buttons appear inline in the workflow card only when `expense.status === "ManualReviewRequested"`, keeping the UI minimal and context-specific.
+- Adjusted history polling from 10 s to 5 s to match the issue requirement.
+- Used `--approve` / `--reject` CSS modifier classes styled with the existing `--success` / `--danger` CSS variables; no new design system tokens needed.
+- Chose not to introduce a new `src/dashboard/` Next.js app — the existing vanilla UI in `wwwroot/app/` already satisfies all requirements with zero toolchain overhead.

--- a/src/expense-api/wwwroot/app/app.js
+++ b/src/expense-api/wwwroot/app/app.js
@@ -402,8 +402,51 @@ function renderWorkflow(expense, workflowOrError) {
             ${workflow?.failureDetails
                 ? `<div class="trace-item"><strong>Failure details</strong><span>${escapeHtml(workflow.failureDetails)}</span></div>`
                 : ""}
+            ${expense.status === "ManualReviewRequested"
+                ? `<div class="approval-actions">
+                    <p class="approval-label">This expense is held for manual review. Approve or reject to signal the workflow.</p>
+                    <div class="approval-buttons">
+                        <button class="button button--approve" type="button" data-action="approve" data-expense-id="${escapeHtml(expense.expenseId)}">Approve</button>
+                        <button class="button button--reject" type="button" data-action="reject" data-expense-id="${escapeHtml(expense.expenseId)}">Reject</button>
+                    </div>
+                    <div id="approval-feedback" class="feedback" role="status" aria-live="polite"></div>
+                   </div>`
+                : ""}
         </div>
     `;
+
+    elements.workflow.querySelectorAll("[data-action]").forEach((btn) => {
+        btn.addEventListener("click", () =>
+            handleApproval(btn.getAttribute("data-expense-id"), btn.getAttribute("data-action")));
+    });
+}
+
+async function handleApproval(expenseId, action) {
+    const feedbackEl = document.querySelector("#approval-feedback");
+    const buttons = elements.workflow.querySelectorAll("[data-action]");
+
+    buttons.forEach((b) => { b.disabled = true; });
+    if (feedbackEl) feedbackEl.textContent = `Sending ${action} signal\u2026`;
+
+    try {
+        const response = await fetch(`/expenses/${encodeURIComponent(expenseId)}/${action}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({})
+        });
+
+        if (response.ok) {
+            if (feedbackEl) feedbackEl.textContent = `${action === "approve" ? "Approved" : "Rejected"} \u2014 refreshing\u2026`;
+            await refreshExpenses(false, expenseId);
+        } else {
+            const problem = await safeProblem(response);
+            if (feedbackEl) feedbackEl.textContent = `Failed: ${extractProblemDetails(problem) || response.statusText}`;
+            buttons.forEach((b) => { b.disabled = false; });
+        }
+    } catch (err) {
+        if (feedbackEl) feedbackEl.textContent = `Network error: ${err.message}`;
+        buttons.forEach((b) => { b.disabled = false; });
+    }
 }
 
 function buildTimeline(expense, workflow) {
@@ -524,7 +567,7 @@ function startPolling() {
 
     state.historyTimer = window.setInterval(() => {
         refreshExpenses(true);
-    }, 10000);
+    }, 5000);
 
     state.selectedTimer = window.setInterval(() => {
         if (state.selectedExpenseId) {

--- a/src/expense-api/wwwroot/app/styles.css
+++ b/src/expense-api/wwwroot/app/styles.css
@@ -597,3 +597,58 @@ input:focus-visible,
         align-items: stretch;
     }
 }
+
+/* Approve / reject action block */
+.approval-actions {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.approval-label {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+}
+
+.approval-buttons {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.button--approve {
+    background: rgba(78, 217, 168, 0.18);
+    color: var(--success);
+    border: 1px solid rgba(78, 217, 168, 0.35);
+    padding: 8px 20px;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.button--approve:hover:not([disabled]) {
+    background: rgba(78, 217, 168, 0.30);
+}
+
+.button--reject {
+    background: rgba(255, 123, 143, 0.15);
+    color: var(--danger);
+    border: 1px solid rgba(255, 123, 143, 0.35);
+    padding: 8px 20px;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.button--reject:hover:not([disabled]) {
+    background: rgba(255, 123, 143, 0.28);
+}
+
+.button--approve[disabled],
+.button--reject[disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

Adds approve/reject controls to the existing vanilla JS dashboard at `/app`, completing the workflow monitoring requirements from issue #15.

The dashboard already covered expense listing, timeline/history, and auto-refresh. This PR adds the missing manual-review action surface.

## Changes

- **`app.js`**: Added `handleApproval()` function; approve/reject buttons appear in the workflow card when `expense.status === "ManualReviewRequested"`; buttons call `POST /expenses/{id}/approve` and `POST /expenses/{id}/reject` (Simone's PR #20 endpoints); history polling reduced from 10s → 5s.
- **`styles.css`**: Added `.approval-actions`, `.button--approve`, `.button--reject` using existing `--success` / `--danger` CSS tokens.

## Why vanilla JS (not Next.js)

The existing `wwwroot/app/` surface already satisfies all four requirements. A separate `src/dashboard/` Next.js app would add a build toolchain, CORS config, and deployment surface with no user-visible gain.

## Demo flow

1. Submit a `$150` expense — it enters `ManualReviewRequested` state.
2. Select it in the expense list — the workflow card shows **Approve** / **Reject** buttons.
3. Click Approve → button disables, feedback shows "Approved — refreshing…", expense moves to `Approved` state.

Closes #15