### PR TITLE
feat(infra): automate GHCR image pull secret creation

### DIFF
--- a/.squad/agents/pete/history.md
+++ b/.squad/agents/pete/history.md
@@ -279,3 +279,23 @@ All 8 findings from Pete's infrastructure scripts audit were successfully applie
 **Verification:** `bash -n scripts/*.sh` all pass; grep for ACA patterns returns zero results.
 
 **PR:** squad/12-aca-cleanup → closes #12
+
+## Learnings
+
+### 2026-06-05 -- GHCR Image Pull Secret Automation (Issue #16)
+
+**Problem:** Creating the `ghcr-pull-secret` Kubernetes secret was a manual step after every fresh cluster build. Operators who skipped it saw silent pod scheduling failures because AKS could not pull images from `ghcr.io/wesback`.
+
+**Fix applied:**
+
+- Added `GHCR_TOKEN="${GHCR_TOKEN:-}"` and `GHCR_USERNAME="wesback"` variables at top of `prepare-cluster.sh`.
+- Added `--ghcr-token <token>` CLI flag (overrides env var) with matching `usage()` documentation.
+- Introduced `ensure_ghcr_pull_secret()` function that runs after kubectl is confirmed reachable. Uses the idempotent `--dry-run=client -o yaml | kubectl apply -f -` pattern.
+- When token is absent, emits a clear warning (no hard fail) -- script completes, missing secret surfaced in summary line.
+- Added `GHCR_TOKEN` row to the README "Required Repository Secrets" table.
+
+**Key pattern -- pipe in dry-run context:** `run_cmd` uses `"$@"` and cannot carry pipes. Handle dry-run inline like `install_radius_if_needed`: check `[ "$DRY_RUN" = true ]` explicitly.
+
+**Verification:** `bash -n scripts/prepare-cluster.sh` passes.
+
+**PR:** squad/16-ghcr-pull-secret closes #16

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ The GitHub Actions workflow (`.github/workflows/deploy-azure.yml`) deploys to Ku
 | `AZURE_CLIENT_SECRET` | Azure service principal client secret used when registering Radius Azure credentials in CI | ✅ Yes |
 | `AZURE_TENANT_ID` | Azure tenant ID used when registering Radius Azure credentials in CI | ✅ Yes |
 | `RADIUS_KUBECONFIG` | Raw kubeconfig content for the Kubernetes cluster that hosts Radius and the app workloads | ✅ Yes |
+| `GHCR_TOKEN` | GitHub personal access token with `read:packages` scope -- used by `prepare-cluster.sh` to create the `ghcr-pull-secret` image pull secret so AKS can pull images from `ghcr.io/wesback` | ✅ Yes (for `prepare-cluster.sh`) |
 
 ### Required Repository Variables
 

--- a/scripts/prepare-cluster.sh
+++ b/scripts/prepare-cluster.sh
@@ -21,6 +21,9 @@ INSTALL_DAPR=false
 INSTALL_RADIUS=false
 YES=false
 DRY_RUN=false
+# GHCR pull secret -- read from env var first, overridden by --ghcr-token flag
+GHCR_TOKEN="${GHCR_TOKEN:-}"
+GHCR_USERNAME="wesback"
 
 usage() {
   cat <<USAGE
@@ -48,6 +51,9 @@ Optional:
   --workspace-name <name>       Radius workspace name (default: ${WORKSPACE_NAME})
   --group-name <name>           Radius group name (default: ${GROUP_NAME})
   --kube-context <context>      kubectl context to use after credentials are set
+  --ghcr-token <token>          GitHub personal access token (read:packages) for GHCR image pulls.
+                                Falls back to $GHCR_TOKEN env var. When absent, the pull secret
+                                step is skipped with a warning.
   --dry-run                     Print the planned mutations without executing them
   --yes                         Accept confirmation prompts non-interactively
   --help                        Show this help message
@@ -115,6 +121,10 @@ while [ $# -gt 0 ]; do
       ;;
     --kube-context)
       KUBE_CONTEXT="$2"
+      shift 2
+      ;;
+    --ghcr-token)
+      GHCR_TOKEN="$2"
       shift 2
       ;;
     --dry-run)
@@ -310,6 +320,40 @@ install_radius_if_needed() {
   fi
 }
 
+# ensure_ghcr_pull_secret -- creates (or updates) the ghcr-pull-secret in
+# the default namespace so Kubernetes can pull images from ghcr.io/wesback.
+# Uses --dry-run=client | apply so the operation is idempotent.
+# Skipped with a warning when GHCR_TOKEN is empty.
+ensure_ghcr_pull_secret() {
+  section "GHCR image pull secret"
+
+  if [ -z "$GHCR_TOKEN" ]; then
+    log_warning "GHCR_TOKEN is not set -- skipping pull secret creation."
+    log_warning "Pods that pull from ghcr.io/${GHCR_USERNAME} will fail to start on a fresh cluster."
+    log_warning "Re-run with --ghcr-token <token> or export GHCR_TOKEN=<token> to create it."
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "[dry-run] kubectl create secret docker-registry ghcr-pull-secret \\"
+    echo "    --docker-server=ghcr.io \\"
+    echo "    --docker-username=${GHCR_USERNAME} \\"
+    echo "    --docker-password=<GHCR_TOKEN> \\"
+    echo "    --namespace=default \\"
+    echo "    --dry-run=client -o yaml | kubectl apply -f -"
+    return 0
+  fi
+
+  kubectl create secret docker-registry ghcr-pull-secret \
+    --docker-server=ghcr.io \
+    --docker-username="${GHCR_USERNAME}" \
+    --docker-password="${GHCR_TOKEN}" \
+    --namespace=default \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  log_success "ghcr-pull-secret is present in namespace 'default'"
+}
+
 prepare_aks_cluster() {
   [ -n "$AKS_CLUSTER_NAME" ] || return 0
 
@@ -500,6 +544,8 @@ if [ "$DRY_RUN" = false ]; then
   kubectl get nodes -o name >/dev/null 2>&1 || fail "kubectl cannot list cluster nodes."
 fi
 
+ensure_ghcr_pull_secret
+
 section "Cluster control planes"
 install_dapr_if_needed
 install_radius_if_needed
@@ -538,6 +584,11 @@ fi
 echo "kubectl context    : ${KUBECTL_CONTEXT}"
 echo "Radius workspace   : ${WORKSPACE_NAME}"
 echo "Radius group       : ${GROUP_NAME}"
+if [ -n "$GHCR_TOKEN" ]; then
+  echo "GHCR pull secret   : ghcr-pull-secret (namespace: default)"
+else
+  echo "GHCR pull secret   : skipped -- set GHCR_TOKEN or pass --ghcr-token"
+fi
 echo "Next command       : ./scripts/bootstrap.sh --resource-group ${RESOURCE_GROUP} --yes"
 
 if [ "$DRY_RUN" = true ]; then


### PR DESCRIPTION
## Summary

Automates creation of the `ghcr-pull-secret` Kubernetes image pull secret as part of `prepare-cluster.sh`, eliminating a previously manual step that caused silent pod scheduling failures on fresh clusters.

## Changes

### `scripts/prepare-cluster.sh`
- Added `GHCR_TOKEN=${GHCR_TOKEN:-}` and `GHCR_USERNAME=wesback` variables
- Added `--ghcr-token <token>` CLI flag (env var takes precedence, flag overrides)
- New `ensure_ghcr_pull_secret()` function called after kubectl is confirmed reachable
- Uses `--dry-run=client -o yaml | kubectl apply -f -` pattern for idempotency
- Graceful skip with clear warning when token is absent (no hard fail)
- Summary line shows pull secret status

### `README.md`
- Added `GHCR_TOKEN` to the Required Repository Secrets table

## Usage

```bash
# Via flag
./scripts/prepare-cluster.sh --resource-group radiusclaim-rg --ghcr-token ghp_xxx

# Via env var
export GHCR_TOKEN=ghp_xxx
./scripts/prepare-cluster.sh --resource-group radiusclaim-rg
```

## Verification

```
bash -n scripts/prepare-cluster.sh  # passes
```

Closes #16