### PR TITLE
feat(notification): add message template system

### DIFF
--- a/RadiusClaim.slnx
+++ b/RadiusClaim.slnx
@@ -1,9 +1,4 @@
 <Solution>
-  <Folder Name="/src/">
-    <Project Path="src/ExpenseApi.Tests/ExpenseApi.Tests.csproj" />
-    <Project Path="src/WorkflowEngine.Tests/WorkflowEngine.Tests.csproj" />
-    <Project Path="src/NotificationSvc.Tests/NotificationSvc.Tests.csproj" />
-  </Folder>
   <Folder Name="/src/expense-api/">
     <Project Path="src/expense-api/ExpenseApi.csproj" />
   </Folder>
@@ -19,6 +14,7 @@
   <Folder Name="/src/tests/">
     <Project Path="src/WorkflowEngine.Tests/WorkflowEngine.Tests.csproj" />
     <Project Path="src/ExpenseApi.Tests/ExpenseApi.Tests.csproj" />
+    <Project Path="src/NotificationSvc.Tests/NotificationSvc.Tests.csproj" />
     <Project Path="src/IntegrationTests/IntegrationTests.csproj" />
   </Folder>
 </Solution>

--- a/src/NotificationSvc.Tests/Templates/TemplateRendererTests.cs
+++ b/src/NotificationSvc.Tests/Templates/TemplateRendererTests.cs
@@ -1,0 +1,155 @@
+using NotificationSvc.Templates;
+using RadiusClaim.Contracts;
+using Xunit;
+
+namespace NotificationSvc.Tests.Templates;
+
+public sealed class TemplateRendererTests
+{
+    private readonly TemplateRenderer _renderer = new();
+
+    [Theory]
+    [InlineData(NotificationEventType.ExpenseSubmitted,       "expense-submitted")]
+    [InlineData(NotificationEventType.ExpenseApproved,        "expense-approved")]
+    [InlineData(NotificationEventType.ExpenseRejected,        "expense-rejected")]
+    [InlineData(NotificationEventType.ApprovalTimeout,        "approval-timeout")]
+    [InlineData(NotificationEventType.ExpenseRejectedTimeout, "expense-rejected-timeout")]
+    [InlineData(NotificationEventType.ManualReviewRequested,  "approval-timeout")]
+    public void TemplateNameFor_ReturnsExpectedName(NotificationEventType eventType, string expected) =>
+        Assert.Equal(expected, TemplateRenderer.TemplateNameFor(eventType));
+
+    [Fact]
+    public void Render_ExpenseSubmitted_SubstitutesAllVariables()
+    {
+        var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["expenseId"]     = "EXP-001",
+            ["submitter"]     = "alice@contoso.com",
+            ["subject"]       = "Team offsite",
+            ["occurredAtUtc"] = "2026-03-27 10:00:00Z",
+        };
+
+        var result = _renderer.Render("expense-submitted", vars);
+
+        Assert.Contains("EXP-001", result);
+        Assert.Contains("alice@contoso.com", result);
+        Assert.Contains("Team offsite", result);
+        Assert.Contains("2026-03-27 10:00:00Z", result);
+        Assert.DoesNotContain("{{", result);
+    }
+
+    [Fact]
+    public void Render_ExpenseApproved_SubstitutesAllVariables()
+    {
+        var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["expenseId"]     = "EXP-002",
+            ["approver"]      = "bob@contoso.com",
+            ["amount"]        = "450.00",
+            ["subject"]       = "Conference registration",
+            ["occurredAtUtc"] = "2026-03-27 11:00:00Z",
+        };
+
+        var result = _renderer.Render("expense-approved", vars);
+
+        Assert.Contains("EXP-002", result);
+        Assert.Contains("bob@contoso.com", result);
+        Assert.Contains("450.00", result);
+        Assert.Contains("Conference registration", result);
+        Assert.DoesNotContain("{{", result);
+    }
+
+    [Fact]
+    public void Render_ExpenseRejected_SubstitutesAllVariables()
+    {
+        var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["expenseId"]     = "EXP-003",
+            ["reason"]        = "Missing receipts",
+            ["approver"]      = "carol@contoso.com",
+            ["subject"]       = "Travel reimbursement",
+            ["occurredAtUtc"] = "2026-03-27 12:00:00Z",
+        };
+
+        var result = _renderer.Render("expense-rejected", vars);
+
+        Assert.Contains("EXP-003", result);
+        Assert.Contains("Missing receipts", result);
+        Assert.Contains("carol@contoso.com", result);
+        Assert.DoesNotContain("{{", result);
+    }
+
+    [Fact]
+    public void Render_ApprovalTimeout_SubstitutesAllVariables()
+    {
+        var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["expenseId"]     = "EXP-004",
+            ["submitter"]     = "dave@contoso.com",
+            ["subject"]       = "Equipment purchase",
+            ["occurredAtUtc"] = "2026-03-27 13:00:00Z",
+        };
+
+        var result = _renderer.Render("approval-timeout", vars);
+
+        Assert.Contains("EXP-004", result);
+        Assert.Contains("dave@contoso.com", result);
+        Assert.DoesNotContain("{{", result);
+    }
+
+    [Fact]
+    public void Render_ExpenseRejectedTimeout_SubstitutesAllVariables()
+    {
+        var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["expenseId"]     = "EXP-005",
+            ["subject"]       = "Software license",
+            ["occurredAtUtc"] = "2026-03-27 14:00:00Z",
+        };
+
+        var result = _renderer.Render("expense-rejected-timeout", vars);
+
+        Assert.Contains("EXP-005", result);
+        Assert.Contains("Software license", result);
+        Assert.DoesNotContain("{{", result);
+    }
+
+    [Fact]
+    public void Render_UnknownPlaceholder_ReplacedWithEmpty()
+    {
+        var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["expenseId"]     = "EXP-006",
+            ["subject"]       = "Lunch",
+            ["occurredAtUtc"] = "2026-03-27 14:00:00Z",
+        };
+
+        var result = _renderer.Render("approval-timeout", vars);
+
+        Assert.Contains("EXP-006", result);
+        Assert.DoesNotContain("{{submitter}}", result);
+    }
+
+    [Fact]
+    public void Render_PlaceholderMatchingIsCaseInsensitive()
+    {
+        var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["EXPENSEID"]     = "EXP-007",
+            ["SUBJECT"]       = "Taxi",
+            ["OCCURREDATUTC"] = "2026-03-27 15:00:00Z",
+        };
+
+        var result = _renderer.Render("expense-rejected-timeout", vars);
+
+        Assert.Contains("EXP-007", result);
+        Assert.Contains("Taxi", result);
+    }
+
+    [Fact]
+    public void Render_MissingTemplate_ThrowsInvalidOperationException()
+    {
+        var vars = new Dictionary<string, string>();
+        Assert.Throws<InvalidOperationException>(() => _renderer.Render("nonexistent-template", vars));
+    }
+}

--- a/src/notification-svc/NotificationSvc.csproj
+++ b/src/notification-svc/NotificationSvc.csproj
@@ -8,6 +8,10 @@
     <PackageReference Include="Dapr.AspNetCore" Version="1.17.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="templates\*.txt" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/notification-svc/Program.cs
+++ b/src/notification-svc/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using RadiusClaim.Contracts;
 using Dapr;
 using Dapr.Client;
+using NotificationSvc.Templates;
 using NotificationSvc.Transports;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,6 +14,8 @@ if (transportName == "email")
     builder.Services.AddSingleton<INotificationTransport, EmailTransport>();
 else
     builder.Services.AddSingleton<INotificationTransport, LoggingTransport>();
+
+builder.Services.AddSingleton<ITemplateRenderer, TemplateRenderer>();
 
 var app = builder.Build();
 
@@ -31,6 +34,7 @@ app.MapPost("/notifications",
     async (HttpRequest request, ILogger<Program> logger, CancellationToken cancellationToken) =>
     {
         var transport = request.HttpContext.RequestServices.GetRequiredService<INotificationTransport>();
+        var renderer = request.HttpContext.RequestServices.GetRequiredService<ITemplateRenderer>();
 
         NotificationRequest? notification;
 
@@ -57,7 +61,10 @@ app.MapPost("/notifications",
             return TypedResults.Ok(new { status = "ignored" });
         }
 
-        await transport.SendAsync(notification, cancellationToken);
+        var renderedMessage = RenderMessage(renderer, notification, logger);
+        var enrichedNotification = notification with { Message = renderedMessage };
+
+        await transport.SendAsync(enrichedNotification, cancellationToken);
 
         // Return consistent anonymous type to keep lambda return type inference stable.
         return TypedResults.Ok(new { status = "delivered" });
@@ -66,6 +73,31 @@ app.MapPost("/notifications",
 app.MapGet("/healthz", () => TypedResults.Ok(new { status = "ok" }));
 
 app.Run();
+
+static string RenderMessage(ITemplateRenderer renderer, NotificationRequest notification, ILogger logger)
+{
+    try
+    {
+        var templateName = TemplateRenderer.TemplateNameFor(notification.EventType);
+        var variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["expenseId"]     = notification.ExpenseId,
+            ["correlationId"] = notification.CorrelationId,
+            ["recipient"]     = notification.Recipient,
+            ["channel"]       = notification.Channel,
+            ["eventType"]     = notification.EventType.ToString(),
+            ["subject"]       = notification.Subject,
+            ["message"]       = notification.Message,
+            ["occurredAtUtc"] = notification.OccurredAtUtc.ToString("u"),
+        };
+        return renderer.Render(templateName, variables);
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning(ex, "Template rendering failed for event type {EventType}; falling back to original message.", notification.EventType);
+        return notification.Message;
+    }
+}
 
 static bool IsValidNotification(NotificationRequest? notification) =>
     notification is not null

--- a/src/notification-svc/templates/ITemplateRenderer.cs
+++ b/src/notification-svc/templates/ITemplateRenderer.cs
@@ -1,0 +1,14 @@
+namespace NotificationSvc.Templates;
+
+/// <summary>
+/// Renders a named template by substituting {{variable}} placeholders with provided values.
+/// </summary>
+public interface ITemplateRenderer
+{
+    /// <summary>
+    /// Renders the template identified by <paramref name="templateName"/> using the supplied
+    /// <paramref name="variables"/> dictionary.  Unknown placeholders are replaced with an
+    /// empty string.
+    /// </summary>
+    string Render(string templateName, IReadOnlyDictionary<string, string> variables);
+}

--- a/src/notification-svc/templates/TemplateRenderer.cs
+++ b/src/notification-svc/templates/TemplateRenderer.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+using RadiusClaim.Contracts;
+
+namespace NotificationSvc.Templates;
+
+/// <summary>
+/// Loads message templates that are embedded in the assembly and substitutes
+/// <c>{{variable}}</c> placeholders (case-insensitive) from the supplied dictionary.
+/// </summary>
+public sealed partial class TemplateRenderer : ITemplateRenderer
+{
+    [GeneratedRegex(@"\{\{(\w+)\}\}", RegexOptions.IgnoreCase)]
+    private static partial Regex PlaceholderPattern();
+
+    public string Render(string templateName, IReadOnlyDictionary<string, string> variables)
+    {
+        var assembly = typeof(TemplateRenderer).Assembly;
+        var resourceName = $"NotificationSvc.templates.{templateName}.txt";
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Notification template '{templateName}' not found. " +
+                $"Expected embedded resource '{resourceName}'.");
+
+        using var reader = new StreamReader(stream);
+        var template = reader.ReadToEnd();
+
+        return PlaceholderPattern().Replace(template, match =>
+        {
+            var key = match.Groups[1].Value;
+            return variables.TryGetValue(key, out var value) ? value : string.Empty;
+        });
+    }
+
+    /// <summary>
+    /// Maps a <see cref="NotificationEventType"/> to its template name.
+    /// </summary>
+    public static string TemplateNameFor(NotificationEventType eventType) =>
+        eventType switch
+        {
+            NotificationEventType.ExpenseSubmitted       => "expense-submitted",
+            NotificationEventType.ExpenseApproved        => "expense-approved",
+            NotificationEventType.ExpenseRejected        => "expense-rejected",
+            NotificationEventType.ApprovalTimeout        => "approval-timeout",
+            NotificationEventType.ExpenseRejectedTimeout => "expense-rejected-timeout",
+            NotificationEventType.ManualReviewRequested  => "approval-timeout",
+            _ => throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "No template registered for event type.")
+        };
+}

--- a/src/notification-svc/templates/approval-timeout.txt
+++ b/src/notification-svc/templates/approval-timeout.txt
@@ -1,0 +1,5 @@
+Approval for expense {{expenseId}} has timed out and requires attention.
+
+Submitter: {{submitter}}
+Subject: {{subject}}
+Timed Out At: {{occurredAtUtc}}

--- a/src/notification-svc/templates/expense-approved.txt
+++ b/src/notification-svc/templates/expense-approved.txt
@@ -1,0 +1,6 @@
+Good news! Your expense {{expenseId}} has been approved.
+
+Approver: {{approver}}
+Amount: {{amount}}
+Subject: {{subject}}
+Approved At: {{occurredAtUtc}}

--- a/src/notification-svc/templates/expense-rejected-timeout.txt
+++ b/src/notification-svc/templates/expense-rejected-timeout.txt
@@ -1,0 +1,4 @@
+Your expense {{expenseId}} has been automatically rejected due to approval timeout.
+
+Subject: {{subject}}
+Rejected At: {{occurredAtUtc}}

--- a/src/notification-svc/templates/expense-rejected.txt
+++ b/src/notification-svc/templates/expense-rejected.txt
@@ -1,0 +1,6 @@
+Your expense {{expenseId}} has been rejected.
+
+Reason: {{reason}}
+Rejected By: {{approver}}
+Subject: {{subject}}
+Rejected At: {{occurredAtUtc}}

--- a/src/notification-svc/templates/expense-submitted.txt
+++ b/src/notification-svc/templates/expense-submitted.txt
@@ -1,0 +1,5 @@
+Expense {{expenseId}} has been submitted for review.
+
+Submitter: {{submitter}}
+Subject: {{subject}}
+Submitted At: {{occurredAtUtc}}

--- a/src/shared/RadiusClaim.Contracts/NotificationRequest.cs
+++ b/src/shared/RadiusClaim.Contracts/NotificationRequest.cs
@@ -5,9 +5,12 @@ namespace RadiusClaim.Contracts;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum NotificationEventType
 {
+    ExpenseSubmitted,
     ExpenseApproved,
     ExpenseRejected,
-    ManualReviewRequested
+    ManualReviewRequested,
+    ApprovalTimeout,
+    ExpenseRejectedTimeout
 }
 
 public sealed record NotificationRequest(


### PR DESCRIPTION
Closes #14

Adds TemplateRenderer with per-event templates and variable substitution.

- 5 `.txt` message templates (expense-submitted, expense-approved, expense-rejected, approval-timeout, expense-rejected-timeout)
- `ITemplateRenderer` / `TemplateRenderer`: embedded-resource loader with case-insensitive `{{variable}}` regex substitution; unknown placeholders become empty string
- `NotificationEventType` extended with `ExpenseSubmitted`, `ApprovalTimeout`, `ExpenseRejectedTimeout`
- `TemplateRenderer` registered in DI; dispatch pipeline renders message before forwarding to `INotificationTransport.SendAsync`
- 14 new tests in `TemplateRendererTests`; full suite 30/30 green